### PR TITLE
New rasimpl tactic to replace asimpl

### DIFF
--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -586,27 +586,7 @@ Proof.
     rasimpl. apply ext_cterm.
     intros [].
     + rasimpl. reflexivity.
-    + rasimpl.
-      unfold up_cterm_cterm, var_zero.
-      change (core.funcomp ?f ?g ?x) with (f (g x)).
-      cbn [scons].
-      change (core.funcomp ?f ?g ?x) with (f (g x)).
-      (* Unset Printing Notations. *)
-      (* Doing those changes break already line 111. *)
-      (* Maybe I should check what happens with the first rasimpl above
-        as it might already be responsible for a divergence with asimpl.
-        Divergence is also ok as long as it gets better.
-
-        TODO: [ρ >> var] should be unquoted as ⟨ ρ ⟩
-        This happens only with qsubst_comp (qsubst_ren ρ) s
-        which is exactly what you get from qsubst_compr_l so maybe that optim
-        was wrong?
-        Maybe I need to see substitutions as combinations of renamings,
-        then proper substs, then term → term things (just renamings again?).
-       *)
-      rasimpl.
-      fail.
-      reflexivity.
+    + rasimpl. reflexivity.
   - rasimpl. constructor.
     + auto.
     + eapply IHh2. apply cstyping_shift. assumption.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -642,40 +642,20 @@ Proof.
       * rasimpl. reflexivity.
       * rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. ssimpl. f_equal. f_equal. f_equal.
-      eapply ext_cterm.
-      intros [].
-      * ssimpl. reflexivity.
-      * ssimpl. reflexivity.
+      clear. f_equal. rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. f_equal. ssimpl. f_equal.
-      * {
-        f_equal. f_equal. eapply ext_cterm.
-        intros [].
-        - ssimpl. reflexivity.
-        - ssimpl. reflexivity.
-      }
-      * {
-        f_equal. all: f_equal. all: f_equal. all: f_equal.
-        - eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-        - eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-        - eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-      }
+      clear. f_equal. f_equal. rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     eapply cmeta_conv. 1: eauto.
-    f_equal. f_equal.
-    ssimpl. f_equal. all: f_equal. all: f_equal.
-    + eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-    + eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
+    clear. f_equal. f_equal.
+    rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     eapply cmeta_conv. 1: eauto.
-    f_equal. ssimpl. f_equal. f_equal. all: f_equal. all: f_equal.
-    + eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-    + eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
+    f_equal. rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
     rasimpl in IHht8. rasimpl in IHht9. rasimpl in IHht10. rasimpl in IHht11.
@@ -683,70 +663,37 @@ Proof.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
       f_equal. f_equal.
-      ssimpl. f_equal. all: f_equal. all: f_equal. 2,3: f_equal. 4: f_equal.
-      * eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-      * eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-      * eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-      * eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
+      rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. ssimpl. f_equal. f_equal.  all: f_equal. all: f_equal.
-      * eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-      * eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
+      f_equal. rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. ssimpl. f_equal. f_equal. f_equal. unfold capps. cbn. f_equal.
-      all: f_equal. all: f_equal. 2-4: f_equal.
-      4-6: f_equal. 5-7: f_equal. 5-7: f_equal. 5-7: f_equal.
-      5-6: f_equal.
-      all: ssimpl.
-      all: eapply ext_cterm ; intros [] ; ssimpl ; reflexivity.
+      f_equal. rasimpl. f_equal. f_equal. f_equal. unfold capps. cbn. f_equal.
+      f_equal. f_equal. f_equal. all: f_equal. all: f_equal. all: f_equal.
+      all: f_equal. 1,2: f_equal.
+      all: rasimpl. all: reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
     rasimpl in IHht8. rasimpl in IHht9. rasimpl in IHht10. rasimpl in IHht11.
     rasimpl in IHht12.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. f_equal.
-      ssimpl. f_equal. all: f_equal. all: f_equal. 2,3: f_equal. 4: f_equal.
-      * eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-      * eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-      * eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-      * eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
+      clear. f_equal. f_equal.
+      rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. ssimpl. f_equal. f_equal.  all: f_equal. all: f_equal.
-      2,3: f_equal.
-      * eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-      * eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-      * eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
+      clear. f_equal. rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. ssimpl. f_equal. f_equal. f_equal. unfold capps. cbn. f_equal.
-      all: f_equal. all: f_equal. 2-4: f_equal.
-      4-6: f_equal. 5-7: f_equal. 5-7: f_equal. 5-7: f_equal.
-      5-7: f_equal.
-      all: ssimpl.
-      all: eapply ext_cterm ; intros [] ; ssimpl ; reflexivity.
-    + cbn. unfold elength. f_equal. f_equal. f_equal.
-      ssimpl. f_equal. f_equal. f_equal.
-      all: f_equal. 2,3: f_equal. 2-4: f_equal. 2,4: f_equal.
-      3: f_equal.
-      all: ssimpl.
-      all: eapply ext_cterm ; intros [] ; ssimpl ; reflexivity.
+      clear. f_equal. rasimpl. unfold capps. cbn. rasimpl. reflexivity.
+    + clear. cbn. unfold elength. f_equal. f_equal. f_equal.
+      rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
     rasimpl in IHht8. rasimpl in IHht9. rasimpl in IHht10.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. f_equal.
-      ssimpl. f_equal. all: f_equal. all: f_equal. 2: f_equal.
-      * eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-      * eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-      * eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
+      clear. f_equal. f_equal.
+      rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      unfold capps. cbn.
-      f_equal. ssimpl. f_equal. clear. f_equal. f_equal. f_equal. all: f_equal.
-      all: f_equal. 2-4: f_equal. 4-5: f_equal. 5: f_equal. 5: f_equal.
-      4: f_equal. 4: f_equal.
-      all: ssimpl.
-      all: eapply ext_cterm ; intros [] ; ssimpl ; reflexivity.
+      clear. unfold capps. cbn. rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2.
     econstructor. all: eauto.
     eapply cconv_subst. all: eassumption.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -618,10 +618,10 @@ Proof.
     rasimpl. apply ext_cterm. intros [].
     + rasimpl. reflexivity.
     + rasimpl. reflexivity.
-  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. asimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     rasimpl. eauto.
-  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
+  - rasimpl. rasimpl in IHht1. asimpl in IHht2. rasimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     instantiate (1 := i). instantiate (1 := m).
     rasimpl. eauto.
@@ -629,9 +629,9 @@ Proof.
     rasimpl in IHht4. rasimpl in IHht5.
     eapply cmeta_conv. 1: econstructor. all: eauto.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
-    rasimpl in IHht4.
+    asimpl in IHht4.
     eapply cmeta_conv. 1: econstructor. all: eauto.
-    rasimpl. eauto.
+    asimpl. eauto.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
     rasimpl in IHht8.
@@ -854,7 +854,7 @@ Proof.
         destruct h as [B [e eB]].
         eapply ccmeta_conv.
         -- econstructor. eassumption.
-        -- cbn. rasimpl.
+        -- cbn. rasimpl. rasimpl in eB.
           erewrite extRen_cterm.
           ++ erewrite <- eB. substify. rasimpl. reflexivity.
           ++ intro. reflexivity.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -192,7 +192,7 @@ Proof.
   intros n m A en. rewrite <- e.
   eapply h in en as [B [en eB]].
   eexists. split. 1: eassumption.
-  rasimpl. rewrite <- eB.
+  asimpl. rewrite <- eB.
   apply extRen_cterm. intro x. cbn. core.unfold_funcomp.
   rewrite <- e. reflexivity.
 Qed.
@@ -314,7 +314,7 @@ Proof.
   induction h in Γ, ρ, hρ |- *.
   all: try solve [ rasimpl ; econstructor ; eauto ; cscoping_ren_finish ].
   - rasimpl. eapply cmeta_conv_trans_r. 1: econstructor.
-    asimpl. reflexivity.
+    rasimpl. reflexivity.
   - rasimpl. constructor.
     + auto.
     + eapply IHh2. apply crtyping_shift. assumption.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -221,7 +221,7 @@ Proof.
   destruct y.
   - cbn in *. noconf hy. eexists.
     split. 1: reflexivity.
-    asimpl. reflexivity.
+    rasimpl. reflexivity.
   - cbn in *. eapply hρ in hy. destruct hy as [C [en eC]].
     eexists. split. 1: eassumption.
     rasimpl.
@@ -700,7 +700,7 @@ Proof.
       5-6: f_equal.
       all: ssimpl.
       all: eapply ext_cterm ; intros [] ; ssimpl ; reflexivity.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
     asimpl in IHht8. asimpl in IHht9. asimpl in IHht10. asimpl in IHht11.
     asimpl in IHht12.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -159,7 +159,7 @@ Proof.
   intros Γ. induction Γ as [| m Γ ih].
   - constructor.
   - constructor.
-    + eapply csscoping_weak with (m := m) in ih. asimpl in ih. assumption.
+    + eapply csscoping_weak with (m := m) in ih. rasimpl in ih. assumption.
     + destruct m. 2: constructor.
       constructor. reflexivity.
 Qed.
@@ -225,7 +225,7 @@ Proof.
   - cbn in *. eapply hρ in hy. destruct hy as [C [en eC]].
     eexists. split. 1: eassumption.
     rasimpl.
-    apply (f_equal (λ t, S ⋅ t)) in eC. asimpl in eC.
+    apply (f_equal (λ t, S ⋅ t)) in eC. rasimpl in eC.
     assumption.
 Qed.
 
@@ -333,31 +333,31 @@ Proof.
   induction ht in Γ, ρ, hρ |- *.
   all: try solve [ rasimpl ; econstructor ; eauto ; cscoping_ren_finish ].
   - rasimpl. eapply hρ in H as [B [? eB]].
-    asimpl in eB. rewrite eB.
+    rasimpl in eB. rewrite eB.
     econstructor. eassumption.
   - rasimpl. econstructor. 1: eauto.
     eapply IHht2. eapply crtyping_shift. assumption.
   - rasimpl. econstructor. 1: eauto.
     eapply IHht2. eapply crtyping_shift. assumption.
-  - rasimpl. asimpl in IHht1.
+  - rasimpl. rasimpl in IHht1.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     rasimpl. reflexivity.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. asimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     rasimpl. eauto.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. rasimpl in IHht1. asimpl in IHht2. rasimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     instantiate (1 := i). instantiate (1 := m).
     rasimpl. eauto.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
-    asimpl in IHht4. asimpl in IHht5.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
+    rasimpl in IHht4. rasimpl in IHht5.
     eapply cmeta_conv. 1: econstructor. all: eauto.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     asimpl in IHht4.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     rasimpl. eauto.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
-    asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
+    asimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. asimpl in IHht7.
     asimpl in IHht8.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
@@ -366,63 +366,63 @@ Proof.
     + eapply cmeta_conv. 1: eauto.
       f_equal. ssimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. f_equal. ssimpl. reflexivity.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
-    asimpl in IHht4. asimpl in IHht5. asimpl in IHht6.
+      f_equal. f_equal. rasimpl. reflexivity.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
+    rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     eapply cmeta_conv. 1: eauto.
     f_equal. f_equal.
-    ssimpl. reflexivity.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
-    asimpl in IHht4. asimpl in IHht5.
+    rasimpl. reflexivity.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
+    rasimpl in IHht4. rasimpl in IHht5.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     eapply cmeta_conv. 1: eauto.
-    f_equal. ssimpl. reflexivity.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
-    asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
-    asimpl in IHht8. asimpl in IHht9. asimpl in IHht10. asimpl in IHht11.
-    asimpl in IHht12.
+    f_equal. rasimpl. reflexivity.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
+    rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
+    rasimpl in IHht8. rasimpl in IHht9. rasimpl in IHht10. rasimpl in IHht11.
+    rasimpl in IHht12.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
       f_equal. f_equal.
-      ssimpl. reflexivity.
+      rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. ssimpl. reflexivity.
+      f_equal. rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. ssimpl. f_equal. f_equal. f_equal. f_equal. f_equal.
+      f_equal. rasimpl. f_equal. f_equal. f_equal. f_equal. f_equal.
       f_equal. unfold capps. cbn. f_equal. all: f_equal.
       all: f_equal. all: f_equal. all: f_equal. 1,2: f_equal.
-      all: ssimpl. all: reflexivity.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
-    asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
-    asimpl in IHht8. asimpl in IHht9. asimpl in IHht10. asimpl in IHht11.
-    asimpl in IHht12.
+      all: rasimpl. all: reflexivity.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
+    rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
+    rasimpl in IHht8. rasimpl in IHht9. rasimpl in IHht10. rasimpl in IHht11.
+    rasimpl in IHht12.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
       f_equal. f_equal.
-      ssimpl. reflexivity.
+      rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. ssimpl. reflexivity.
+      f_equal. rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. ssimpl. f_equal. f_equal. f_equal. f_equal. f_equal.
+      f_equal. rasimpl. f_equal. f_equal. f_equal. f_equal. f_equal.
       f_equal. unfold capps. cbn. f_equal. all: f_equal.
       all: f_equal. all: f_equal. all: f_equal. 1,2: f_equal.
-      all: ssimpl. all: reflexivity.
-    + cbn. unfold elength. f_equal. f_equal. f_equal. ssimpl.
+      all: rasimpl. all: reflexivity.
+    + cbn. unfold elength. f_equal. f_equal. f_equal. rasimpl.
       reflexivity.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
-    asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
-    asimpl in IHht8. asimpl in IHht9. asimpl in IHht10.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
+    rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
+    rasimpl in IHht8. rasimpl in IHht9. rasimpl in IHht10.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
       f_equal. f_equal.
-      ssimpl. reflexivity.
+      rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. ssimpl. f_equal. f_equal. f_equal. f_equal.
+      f_equal. rasimpl. f_equal. f_equal. f_equal. f_equal.
       f_equal. cbn. f_equal.
       all: f_equal. all: f_equal. all: f_equal. all: f_equal.
-      all: ssimpl. all: reflexivity.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2.
+      all: rasimpl. all: reflexivity.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2.
     econstructor. all: eauto.
     eapply cconv_ren. all: eassumption.
 Qed.
@@ -488,7 +488,7 @@ Proof.
           intros n ? ? e. rasimpl. cbn.
           eexists. split. 1: eassumption.
           reflexivity.
-        -- asimpl. reflexivity.
+        -- rasimpl. reflexivity.
 Qed.
 
 Lemma cstyping_weak_none :
@@ -510,7 +510,7 @@ Proof.
           intros n ? ? e. rasimpl. cbn.
           eexists. split. 1: eassumption.
           reflexivity.
-        -- asimpl. reflexivity.
+        -- rasimpl. reflexivity.
 Qed.
 
 Lemma cstyping_shift :
@@ -525,7 +525,7 @@ Proof.
     + constructor. reflexivity.
     + eapply cmeta_conv.
       * econstructor. cbn. reflexivity.
-      * asimpl. reflexivity.
+      * rasimpl. reflexivity.
 Qed.
 
 Lemma cstyping_shift_none :
@@ -547,13 +547,13 @@ Proof.
   - constructor.
   - constructor. 2: split.
     + eapply cstyping_weak with (mx := m) (A := A) in ih.
-      asimpl in ih. assumption.
+      rasimpl in ih. assumption.
     + constructor. reflexivity.
     + eapply cmeta_conv. 1: econstructor.
       * cbn. reflexivity.
       * rasimpl. substify. reflexivity.
   - constructor. 2: constructor.
-    eapply cstyping_weak_none in ih. asimpl in ih. assumption.
+    eapply cstyping_weak_none in ih. rasimpl in ih. assumption.
 Qed.
 
 Lemma cstyping_one :
@@ -563,9 +563,9 @@ Lemma cstyping_one :
     cstyping Γ u.. (Some (mx, A) :: Γ).
 Proof.
   intros Γ mx A u h hm.
-  constructor. all: rasimpl.
+  constructor. all: asimpl.
   - apply cstyping_ids.
-  - cbn. intuition auto. asimpl. assumption.
+  - cbn. intuition auto. rasimpl. assumption.
 Qed.
 
 Ltac cscoping_subst_finish :=
@@ -583,10 +583,22 @@ Proof.
   induction h in Γ, σ, hσ |- *.
   all: try solve [ rasimpl ; econstructor ; eauto ; cscoping_subst_finish ].
   - rasimpl. eapply cmeta_conv_trans_r. 1: econstructor.
-    asimpl. apply ext_cterm.
+    rasimpl. apply ext_cterm.
     intros [].
     + rasimpl. reflexivity.
-    + asimpl. reflexivity.
+    + rasimpl.
+      unfold up_cterm_cterm, var_zero.
+      change (core.funcomp ?f ?g ?x) with (f (g x)).
+      cbn [scons].
+      change (core.funcomp ?f ?g ?x) with (f (g x)).
+      (* Unset Printing Notations. *)
+      (* Doing those changes break already line 111. *)
+      (* Maybe I should check what happens with the first rasimpl above
+        as it might already be responsible for a divergence with asimpl.
+        Divergence is also ok as long as it gets better.
+       *)
+      rasimpl.
+      reflexivity.
   - rasimpl. constructor.
     + auto.
     + eapply IHh2. apply cstyping_shift. assumption.
@@ -604,7 +616,7 @@ Proof.
   intros Γ Δ σ t A hσ ht.
   induction ht in Γ, σ, hσ |- *.
   all: try solve [ rasimpl ; econstructor ; eauto ; cscoping_subst_finish ].
-  - asimpl.
+  - rasimpl.
     induction hσ in x, H |- *. 1: destruct x ; discriminate.
     destruct x.
     + cbn in H. noconf H. cbn in *. intuition assumption.
@@ -613,28 +625,28 @@ Proof.
     eapply IHht2. eapply cstyping_shift. assumption.
   - rasimpl. econstructor. 1: eauto.
     eapply IHht2. eapply cstyping_shift. assumption.
-  - rasimpl. asimpl in IHht1.
+  - rasimpl. rasimpl in IHht1.
     eapply cmeta_conv. 1: econstructor. all: eauto.
-    asimpl. apply ext_cterm. intros [].
-    + asimpl. reflexivity.
-    + asimpl. reflexivity.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+    rasimpl. apply ext_cterm. intros [].
+    + rasimpl. reflexivity.
+    + rasimpl. reflexivity.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
-    asimpl. eauto.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+    rasimpl. eauto.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     instantiate (1 := i). instantiate (1 := m).
-    asimpl. eauto.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
-    asimpl in IHht4. asimpl in IHht5.
+    rasimpl. eauto.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
+    rasimpl in IHht4. rasimpl in IHht5.
     eapply cmeta_conv. 1: econstructor. all: eauto.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
-    asimpl in IHht4.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
+    rasimpl in IHht4.
     eapply cmeta_conv. 1: econstructor. all: eauto.
-    asimpl. eauto.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
-    asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
-    asimpl in IHht8.
+    rasimpl. eauto.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
+    rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
+    rasimpl in IHht8.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
       f_equal. f_equal. f_equal. f_equal. f_equal.
@@ -662,25 +674,25 @@ Proof.
         - eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
         - eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
       }
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
-    asimpl in IHht4. asimpl in IHht5. asimpl in IHht6.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
+    rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     eapply cmeta_conv. 1: eauto.
     f_equal. f_equal.
     ssimpl. f_equal. all: f_equal. all: f_equal.
     + eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
     + eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
-    asimpl in IHht4. asimpl in IHht5.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
+    rasimpl in IHht4. rasimpl in IHht5.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     eapply cmeta_conv. 1: eauto.
     f_equal. ssimpl. f_equal. f_equal. all: f_equal. all: f_equal.
     + eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
     + eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
-    asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
-    asimpl in IHht8. asimpl in IHht9. asimpl in IHht10. asimpl in IHht11.
-    asimpl in IHht12.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
+    rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
+    rasimpl in IHht8. rasimpl in IHht9. rasimpl in IHht10. rasimpl in IHht11.
+    rasimpl in IHht12.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
       f_equal. f_equal.
@@ -700,10 +712,10 @@ Proof.
       5-6: f_equal.
       all: ssimpl.
       all: eapply ext_cterm ; intros [] ; ssimpl ; reflexivity.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
-    asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
-    asimpl in IHht8. asimpl in IHht9. asimpl in IHht10. asimpl in IHht11.
-    asimpl in IHht12.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
+    rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
+    rasimpl in IHht8. rasimpl in IHht9. rasimpl in IHht10. rasimpl in IHht11.
+    rasimpl in IHht12.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
       f_equal. f_equal.
@@ -731,9 +743,9 @@ Proof.
       3: f_equal.
       all: ssimpl.
       all: eapply ext_cterm ; intros [] ; ssimpl ; reflexivity.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
-    asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
-    asimpl in IHht8. asimpl in IHht9. asimpl in IHht10.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
+    rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
+    rasimpl in IHht8. rasimpl in IHht9. rasimpl in IHht10.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
       f_equal. f_equal.
@@ -748,7 +760,7 @@ Proof.
       4: f_equal. 4: f_equal.
       all: ssimpl.
       all: eapply ext_cterm ; intros [] ; ssimpl ; reflexivity.
-  - rasimpl. asimpl in IHht1. asimpl in IHht2.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2.
     econstructor. all: eauto.
     eapply cconv_subst. all: eassumption.
 Qed.
@@ -854,7 +866,7 @@ Proof.
         destruct h as [B [e eB]].
         eapply ccmeta_conv.
         -- econstructor. eassumption.
-        -- cbn. asimpl.
+        -- cbn. rasimpl.
           erewrite extRen_cterm.
           ++ erewrite <- eB. substify. rasimpl. reflexivity.
           ++ intro. reflexivity.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -240,8 +240,7 @@ Proof.
   - cbn in *. noconf hy.
   - cbn in *. eapply hρ in hy. destruct hy as [C [en eC]].
     eexists. split. 1: eassumption.
-    apply (f_equal (λ t, S ⋅ t)) in eC.
-    revert eC. ssimpl. intro eC.
+    apply (f_equal (λ t, S ⋅ t)) in eC. rasimpl in eC.
     etransitivity. 2: eapply eC.
     reflexivity.
 Qed.
@@ -362,9 +361,9 @@ Proof.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
       f_equal. f_equal. f_equal. f_equal. f_equal.
-      ssimpl. reflexivity.
+      rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. ssimpl. reflexivity.
+      f_equal. rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
       f_equal. f_equal. rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
@@ -638,10 +637,10 @@ Proof.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
       f_equal. f_equal. f_equal. f_equal. f_equal.
-      ssimpl. eapply ext_cterm.
+      rasimpl. eapply ext_cterm.
       intros [].
-      * ssimpl. reflexivity.
-      * ssimpl. reflexivity.
+      * rasimpl. reflexivity.
+      * rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
       f_equal. ssimpl. f_equal. f_equal. f_equal.
       eapply ext_cterm.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -596,8 +596,16 @@ Proof.
       (* Maybe I should check what happens with the first rasimpl above
         as it might already be responsible for a divergence with asimpl.
         Divergence is also ok as long as it gets better.
+
+        TODO: [ρ >> var] should be unquoted as ⟨ ρ ⟩
+        This happens only with qsubst_comp (qsubst_ren ρ) s
+        which is exactly what you get from qsubst_compr_l so maybe that optim
+        was wrong?
+        Maybe I need to see substitutions as combinations of renamings,
+        then proper substs, then term → term things (just renamings again?).
        *)
       rasimpl.
+      fail.
       reflexivity.
   - rasimpl. constructor.
     + auto.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -192,7 +192,7 @@ Proof.
   intros n m A en. rewrite <- e.
   eapply h in en as [B [en eB]].
   eexists. split. 1: eassumption.
-  asimpl. rewrite <- eB.
+  rewrite <- eB.
   apply extRen_cterm. intro x. cbn. core.unfold_funcomp.
   rewrite <- e. reflexivity.
 Qed.
@@ -341,21 +341,21 @@ Proof.
     eapply IHht2. eapply crtyping_shift. assumption.
   - rasimpl. asimpl in IHht1.
     eapply cmeta_conv. 1: econstructor. all: eauto.
-    asimpl. reflexivity.
+    rasimpl. reflexivity.
   - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
-    asimpl. eauto.
+    rasimpl. eauto.
   - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     instantiate (1 := i). instantiate (1 := m).
-    asimpl. eauto.
+    rasimpl. eauto.
   - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4. asimpl in IHht5.
     eapply cmeta_conv. 1: econstructor. all: eauto.
   - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4.
     eapply cmeta_conv. 1: econstructor. all: eauto.
-    asimpl. eauto.
+    rasimpl. eauto.
   - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
     asimpl in IHht8.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -76,7 +76,7 @@ Proof.
   intros Γ Δ ρ t m hρ ht.
   pose proof crscoping_shift as lem.
   induction ht in Γ, ρ, hρ, lem |- *.
-  all: solve [ asimpl ; econstructor ; eauto ].
+  all: solve [ rasimpl ; econstructor ; eauto ].
 Qed.
 
 Lemma csscoping_weak :
@@ -102,22 +102,22 @@ Lemma cscoping_subst :
 Proof.
   intros Γ Δ σ t m hσ ht.
   induction ht in Γ, σ, hσ |- *.
-  all: try solve [ asimpl ; econstructor ; eauto ].
+  all: try solve [ rasimpl ; econstructor ; eauto ].
   - rename H into hx, Γ0 into Δ.
-    asimpl. induction hσ in x, hx |- *. 1: destruct x ; discriminate.
+    rasimpl. induction hσ in x, hx |- *. 1: destruct x ; discriminate.
     destruct x.
     + simpl in *. inversion hx. subst. assumption.
     + apply IHhσ. simpl in hx. assumption.
-  - asimpl. constructor.
+  - rasimpl. constructor.
     + eauto.
     + apply IHht2. constructor.
-      * asimpl. apply csscoping_weak. assumption.
-      * asimpl. constructor. reflexivity.
-  - asimpl. constructor.
+      * rasimpl. apply csscoping_weak. assumption.
+      * rasimpl. constructor. reflexivity.
+  - rasimpl. constructor.
     + eauto.
     + apply IHht2. constructor.
-      * asimpl. apply csscoping_weak. assumption.
-      * asimpl. constructor. reflexivity.
+      * rasimpl. apply csscoping_weak. assumption.
+      * rasimpl. constructor. reflexivity.
 Qed.
 
 Lemma csscoping_shift :
@@ -127,7 +127,7 @@ Lemma csscoping_shift :
 Proof.
   intros Γ Δ mx σ h.
   constructor.
-  - asimpl. apply csscoping_weak. assumption.
+  - rasimpl. apply csscoping_weak. assumption.
   - destruct mx. 2: constructor.
     cbn. constructor. reflexivity.
 Qed.
@@ -171,7 +171,7 @@ Lemma csscoping_one :
 Proof.
   intros Γ u mx h.
   constructor.
-  - asimpl. apply csscoping_ids.
+  - rasimpl. apply csscoping_ids.
   - cbn. assumption.
 Qed.
 
@@ -192,7 +192,7 @@ Proof.
   intros n m A en. rewrite <- e.
   eapply h in en as [B [en eB]].
   eexists. split. 1: eassumption.
-  asimpl. rewrite <- eB.
+  rasimpl. rewrite <- eB.
   apply extRen_cterm. intro x. cbn. core.unfold_funcomp.
   rewrite <- e. reflexivity.
 Qed.
@@ -224,7 +224,7 @@ Proof.
     asimpl. reflexivity.
   - cbn in *. eapply hρ in hy. destruct hy as [C [en eC]].
     eexists. split. 1: eassumption.
-    asimpl.
+    rasimpl.
     apply (f_equal (λ t, S ⋅ t)) in eC. asimpl in eC.
     assumption.
 Qed.
@@ -251,9 +251,9 @@ Lemma crtyping_S :
     crtyping (Some (m, A) :: Γ) S Γ.
 Proof.
   intros Γ m A. intros x mx B e.
-  simpl. asimpl.
+  simpl. rasimpl.
   eexists. split. 1: eassumption.
-  asimpl. reflexivity.
+  rasimpl. reflexivity.
 Qed.
 
 Lemma crscoping_sscoping :
@@ -265,7 +265,7 @@ Proof.
   induction Δ as [| m Δ ih] in ρ, h |- *.
   - constructor.
   - constructor.
-    + apply ih. asimpl.
+    + apply ih. rasimpl.
       intros x mx e.
       apply h. cbn. assumption.
     + destruct m. 2: constructor.
@@ -312,13 +312,13 @@ Lemma cconv_ren :
 Proof.
   intros Γ Δ ρ u v hρ h.
   induction h in Γ, ρ, hρ |- *.
-  all: try solve [ asimpl ; econstructor ; eauto ; cscoping_ren_finish ].
-  - asimpl. eapply cmeta_conv_trans_r. 1: econstructor.
+  all: try solve [ rasimpl ; econstructor ; eauto ; cscoping_ren_finish ].
+  - rasimpl. eapply cmeta_conv_trans_r. 1: econstructor.
     asimpl. reflexivity.
-  - asimpl. constructor.
+  - rasimpl. constructor.
     + auto.
     + eapply IHh2. apply crtyping_shift. assumption.
-  - asimpl. constructor.
+  - rasimpl. constructor.
     + auto.
     + eapply IHh2. apply crtyping_shift. assumption.
 Qed.
@@ -331,32 +331,32 @@ Lemma ctyping_ren :
 Proof.
   intros Γ Δ ρ t A hρ ht.
   induction ht in Γ, ρ, hρ |- *.
-  all: try solve [ asimpl ; econstructor ; eauto ; cscoping_ren_finish ].
-  - asimpl. eapply hρ in H as [B [? eB]].
+  all: try solve [ rasimpl ; econstructor ; eauto ; cscoping_ren_finish ].
+  - rasimpl. eapply hρ in H as [B [? eB]].
     asimpl in eB. rewrite eB.
     econstructor. eassumption.
-  - asimpl. econstructor. 1: eauto.
+  - rasimpl. econstructor. 1: eauto.
     eapply IHht2. eapply crtyping_shift. assumption.
-  - asimpl. econstructor. 1: eauto.
+  - rasimpl. econstructor. 1: eauto.
     eapply IHht2. eapply crtyping_shift. assumption.
-  - asimpl. asimpl in IHht1.
+  - rasimpl. asimpl in IHht1.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     asimpl. reflexivity.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     asimpl. eauto.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     instantiate (1 := i). instantiate (1 := m).
     asimpl. eauto.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4. asimpl in IHht5.
     eapply cmeta_conv. 1: econstructor. all: eauto.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     asimpl. eauto.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
     asimpl in IHht8.
     eapply cmeta_conv. 1: econstructor. all: eauto.
@@ -367,18 +367,18 @@ Proof.
       f_equal. ssimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
       f_equal. f_equal. ssimpl. reflexivity.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4. asimpl in IHht5. asimpl in IHht6.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     eapply cmeta_conv. 1: eauto.
     f_equal. f_equal.
     ssimpl. reflexivity.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4. asimpl in IHht5.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     eapply cmeta_conv. 1: eauto.
     f_equal. ssimpl. reflexivity.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
     asimpl in IHht8. asimpl in IHht9. asimpl in IHht10. asimpl in IHht11.
     asimpl in IHht12.
@@ -393,7 +393,7 @@ Proof.
       f_equal. unfold capps. cbn. f_equal. all: f_equal.
       all: f_equal. all: f_equal. all: f_equal. 1,2: f_equal.
       all: ssimpl. all: reflexivity.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
     asimpl in IHht8. asimpl in IHht9. asimpl in IHht10. asimpl in IHht11.
     asimpl in IHht12.
@@ -410,7 +410,7 @@ Proof.
       all: ssimpl. all: reflexivity.
     + cbn. unfold elength. f_equal. f_equal. f_equal. ssimpl.
       reflexivity.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
     asimpl in IHht8. asimpl in IHht9. asimpl in IHht10.
     eapply cmeta_conv. 1: econstructor. all: eauto.
@@ -422,7 +422,7 @@ Proof.
       f_equal. cbn. f_equal.
       all: f_equal. all: f_equal. all: f_equal. all: f_equal.
       all: ssimpl. all: reflexivity.
-  - asimpl. asimpl in IHht1. asimpl in IHht2.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2.
     econstructor. all: eauto.
     eapply cconv_ren. all: eassumption.
 Qed.
@@ -453,7 +453,7 @@ Proof.
       cbn in *. split.
       * rewrite <- e. intuition assumption.
       * rewrite <- e. eapply cmeta_conv. 1: intuition eassumption.
-        asimpl. apply ext_cterm.
+        rasimpl. apply ext_cterm.
         intro. apply e.
 Qed.
 
@@ -483,9 +483,9 @@ Proof.
       cbn in *. split.
       * eapply cscoping_ren. 2: intuition eassumption.
         apply crscoping_S.
-      * asimpl. eapply cmeta_conv.
+      * rasimpl. eapply cmeta_conv.
         -- eapply ctyping_ren. 2: intuition eassumption.
-          intros n ? ? e. asimpl. cbn.
+          intros n ? ? e. rasimpl. cbn.
           eexists. split. 1: eassumption.
           reflexivity.
         -- asimpl. reflexivity.
@@ -505,9 +505,9 @@ Proof.
       cbn in *. split.
       * eapply cscoping_ren. 2: intuition eassumption.
         apply crscoping_S.
-      * asimpl. eapply cmeta_conv.
+      * rasimpl. eapply cmeta_conv.
         -- eapply ctyping_ren. 2: intuition eassumption.
-          intros n ? ? e. asimpl. cbn.
+          intros n ? ? e. rasimpl. cbn.
           eexists. split. 1: eassumption.
           reflexivity.
         -- asimpl. reflexivity.
@@ -520,8 +520,8 @@ Lemma cstyping_shift :
 Proof.
   intros Γ Δ mx A σ h.
   constructor.
-  - asimpl. apply cstyping_weak. assumption.
-  - asimpl. cbn. split.
+  - rasimpl. apply cstyping_weak. assumption.
+  - rasimpl. cbn. split.
     + constructor. reflexivity.
     + eapply cmeta_conv.
       * econstructor. cbn. reflexivity.
@@ -535,8 +535,8 @@ Lemma cstyping_shift_none :
 Proof.
   intros Γ Δ σ h.
   constructor.
-  - asimpl. apply cstyping_weak_none. assumption.
-  - asimpl. cbn. constructor.
+  - rasimpl. apply cstyping_weak_none. assumption.
+  - rasimpl. cbn. constructor.
 Qed.
 
 Lemma cstyping_ids :
@@ -551,7 +551,7 @@ Proof.
     + constructor. reflexivity.
     + eapply cmeta_conv. 1: econstructor.
       * cbn. reflexivity.
-      * asimpl. substify. reflexivity.
+      * rasimpl. substify. reflexivity.
   - constructor. 2: constructor.
     eapply cstyping_weak_none in ih. asimpl in ih. assumption.
 Qed.
@@ -563,7 +563,7 @@ Lemma cstyping_one :
     cstyping Γ u.. (Some (mx, A) :: Γ).
 Proof.
   intros Γ mx A u h hm.
-  constructor. all: asimpl.
+  constructor. all: rasimpl.
   - apply cstyping_ids.
   - cbn. intuition auto. asimpl. assumption.
 Qed.
@@ -581,16 +581,16 @@ Lemma cconv_subst :
 Proof.
   intros Γ Δ σ u v hσ h.
   induction h in Γ, σ, hσ |- *.
-  all: try solve [ asimpl ; econstructor ; eauto ; cscoping_subst_finish ].
-  - asimpl. eapply cmeta_conv_trans_r. 1: econstructor.
+  all: try solve [ rasimpl ; econstructor ; eauto ; cscoping_subst_finish ].
+  - rasimpl. eapply cmeta_conv_trans_r. 1: econstructor.
     asimpl. apply ext_cterm.
     intros [].
+    + rasimpl. reflexivity.
     + asimpl. reflexivity.
-    + asimpl. reflexivity.
-  - asimpl. constructor.
+  - rasimpl. constructor.
     + auto.
     + eapply IHh2. apply cstyping_shift. assumption.
-  - asimpl. constructor.
+  - rasimpl. constructor.
     + auto.
     + eapply IHh2. apply cstyping_shift. assumption.
 Qed.
@@ -603,36 +603,36 @@ Lemma ctyping_subst :
 Proof.
   intros Γ Δ σ t A hσ ht.
   induction ht in Γ, σ, hσ |- *.
-  all: try solve [ asimpl ; econstructor ; eauto ; cscoping_subst_finish ].
+  all: try solve [ rasimpl ; econstructor ; eauto ; cscoping_subst_finish ].
   - asimpl.
     induction hσ in x, H |- *. 1: destruct x ; discriminate.
     destruct x.
     + cbn in H. noconf H. cbn in *. intuition assumption.
     + apply IHhσ. assumption.
-  - asimpl. econstructor. 1: eauto.
+  - rasimpl. econstructor. 1: eauto.
     eapply IHht2. eapply cstyping_shift. assumption.
-  - asimpl. econstructor. 1: eauto.
+  - rasimpl. econstructor. 1: eauto.
     eapply IHht2. eapply cstyping_shift. assumption.
-  - asimpl. asimpl in IHht1.
+  - rasimpl. asimpl in IHht1.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     asimpl. apply ext_cterm. intros [].
     + asimpl. reflexivity.
     + asimpl. reflexivity.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     asimpl. eauto.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     instantiate (1 := i). instantiate (1 := m).
     asimpl. eauto.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4. asimpl in IHht5.
     eapply cmeta_conv. 1: econstructor. all: eauto.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     asimpl. eauto.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
     asimpl in IHht8.
     eapply cmeta_conv. 1: econstructor. all: eauto.
@@ -662,7 +662,7 @@ Proof.
         - eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
         - eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
       }
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4. asimpl in IHht5. asimpl in IHht6.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     eapply cmeta_conv. 1: eauto.
@@ -670,14 +670,14 @@ Proof.
     ssimpl. f_equal. all: f_equal. all: f_equal.
     + eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
     + eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4. asimpl in IHht5.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     eapply cmeta_conv. 1: eauto.
     f_equal. ssimpl. f_equal. f_equal. all: f_equal. all: f_equal.
     + eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
     + eapply ext_cterm. intros []. all: ssimpl. all: reflexivity.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
     asimpl in IHht8. asimpl in IHht9. asimpl in IHht10. asimpl in IHht11.
     asimpl in IHht12.
@@ -700,7 +700,7 @@ Proof.
       5-6: f_equal.
       all: ssimpl.
       all: eapply ext_cterm ; intros [] ; ssimpl ; reflexivity.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
     asimpl in IHht8. asimpl in IHht9. asimpl in IHht10. asimpl in IHht11.
     asimpl in IHht12.
@@ -731,7 +731,7 @@ Proof.
       3: f_equal.
       all: ssimpl.
       all: eapply ext_cterm ; intros [] ; ssimpl ; reflexivity.
-  - asimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2. asimpl in IHht3.
     asimpl in IHht4. asimpl in IHht5. asimpl in IHht6. asimpl in IHht7.
     asimpl in IHht8. asimpl in IHht9. asimpl in IHht10.
     eapply cmeta_conv. 1: econstructor. all: eauto.
@@ -748,7 +748,7 @@ Proof.
       4: f_equal. 4: f_equal.
       all: ssimpl.
       all: eapply ext_cterm ; intros [] ; ssimpl ; reflexivity.
-  - asimpl. asimpl in IHht1. asimpl in IHht2.
+  - rasimpl. asimpl in IHht1. asimpl in IHht2.
     econstructor. all: eauto.
     eapply cconv_subst. all: eassumption.
 Qed.
@@ -764,7 +764,7 @@ Lemma csscoping_one_none :
 Proof.
   intros Γ u.
   constructor.
-  - asimpl. apply csscoping_ids.
+  - rasimpl. apply csscoping_ids.
   - cbn. auto.
 Qed.
 
@@ -773,7 +773,7 @@ Lemma cstyping_one_none :
     cstyping Γ u.. (None :: Γ).
 Proof.
   intros Γ u.
-  constructor. all: asimpl.
+  constructor. all: rasimpl.
   - apply cstyping_ids.
   - cbn. auto.
 Qed.
@@ -822,7 +822,7 @@ Lemma csscoping_nones :
     csscoping (Some m :: Γ) nones (None :: Γ).
 Proof.
   intros Γ m. unfold nones. constructor.
-  - asimpl. apply crscoping_sscoping. apply crscoping_S.
+  - rasimpl. apply crscoping_sscoping. apply crscoping_S.
   - cbn. constructor.
 Qed.
 
@@ -844,7 +844,7 @@ Proof.
   induction Δ as [| o Δ ih] in ρ, h |- *.
   - constructor.
   - constructor.
-    + apply ih. asimpl.
+    + apply ih. rasimpl.
       intros x mx A e.
       apply h. cbn. assumption.
     + destruct o as [[]|]. 2: constructor.
@@ -856,7 +856,7 @@ Proof.
         -- econstructor. eassumption.
         -- cbn. asimpl.
           erewrite extRen_cterm.
-          ++ erewrite <- eB. substify. asimpl. reflexivity.
+          ++ erewrite <- eB. substify. rasimpl. reflexivity.
           ++ intro. reflexivity.
 Qed.
 
@@ -865,7 +865,7 @@ Lemma cstyping_nones :
     cstyping (Some (m, A) :: Γ) nones (None :: Γ).
 Proof.
   intros Γ m A. unfold nones. constructor.
-  - asimpl. eapply crtyping_typing. apply crtyping_S.
+  - rasimpl. eapply crtyping_typing. apply crtyping_S.
   - cbn. auto.
 Qed.
 

--- a/theories/Erasure.v
+++ b/theories/Erasure.v
@@ -299,7 +299,7 @@ Lemma erase_ren :
 Proof.
   intros Γ Δ ρ t hρ hcρ.
   induction t in Γ, Δ, ρ, hρ, hcρ |- *.
-  all: try solve [ asimpl ; cbn ; eauto ].
+  all: try solve [ rasimpl ; cbn ; eauto ].
   - cbn.
     unfold relv.
     destruct (nth_error Δ n) eqn:e.
@@ -314,8 +314,8 @@ Proof.
     2:{ eapply rscoping_upren. eassumption. }
     2:{ eapply rscoping_comp_upren. assumption. }
     destruct_ifs. all: try solve [ eauto ].
-    2:{ unfold close. ssimpl. cbn. unfold cty_lift. ssimpl. reflexivity. }
-    ssimpl. cbn. ssimpl. unfold nones. ssimpl. reflexivity.
+    2:{ unfold close. ssimpl. cbn. unfold cty_lift. rasimpl. reflexivity. }
+    rasimpl. asimpl. unfold nones. rasimpl. reflexivity.
   - cbn.
     erewrite IHt1. 2,3: eassumption.
     erewrite IHt2.
@@ -325,7 +325,7 @@ Proof.
     2:{ eapply rscoping_upren. eassumption. }
     2:{ eapply rscoping_comp_upren. assumption. }
     destruct_ifs. all: eauto.
-    unfold close. ssimpl. reflexivity.
+    unfold close. rasimpl. asimpl. reflexivity.
   - cbn.
     erewrite IHt1. 2,3: eassumption.
     erewrite IHt2. 2,3: eassumption.
@@ -338,7 +338,7 @@ Proof.
     erewrite IHt3. 2,3: eassumption.
     erewrite IHt4. 2,3: eassumption.
     destruct_ifs. all: eauto.
-    cbn. f_equal. ssimpl. reflexivity.
+    cbn. f_equal. rasimpl. reflexivity.
   - cbn. erewrite IHt. 2,3: eassumption.
     reflexivity.
   - cbn.
@@ -370,12 +370,12 @@ Lemma erase_subst :
 Proof.
   intros Γ Δ σ t hσ hcσ.
   induction t in Γ, Δ, σ, hσ, hcσ |- *.
-  all: try solve [ asimpl ; cbn ; eauto ].
-  (* all: try solve [ cbn  ; destruct_ifs ; ssimpl ; eauto ]. *)
+  all: try solve [ rasimpl ; cbn ; eauto ].
+  (* all: try solve [ cbn  ; destruct_ifs ; rasimpl ; eauto ]. *)
   (* Solves only 1 *)
-  - ssimpl. cbn. unfold relv. destruct (nth_error Δ n) eqn:e.
+  - rasimpl. cbn. unfold relv. destruct (nth_error Δ n) eqn:e.
     + destruct (relm m) eqn:em.
-      * cbn. ssimpl. reflexivity.
+      * cbn. rasimpl. reflexivity.
       * cbn. eapply erase_irr. clear hcσ.
         induction hσ as [| σ Δ mx hσ ih hm] in n, m, e, em |- *.
         1: destruct n ; discriminate.
@@ -394,49 +394,46 @@ Proof.
     erewrite IHt1. 2,3: eauto.
     erewrite IHt2.
     2:{ eapply sscoping_shift. eassumption. }
-    2:{ ssimpl. eapply sscoping_comp_shift. assumption. }
+    2:{ rasimpl. eapply sscoping_comp_shift. assumption. }
     destruct_ifs.
-    + cbn. ssimpl. f_equal. all: f_equal. all: f_equal.
+    + cbn. rasimpl. f_equal. all: f_equal. all: f_equal.
       * eapply ext_cterm. intros [].
-        -- ssimpl. cbn. destruct_if e'. 2: discriminate.
+        -- rasimpl. cbn. destruct_if e'. 2: discriminate.
           reflexivity.
-        -- ssimpl. cbn. ssimpl.
+        -- rasimpl. cbn. unfold funcomp.
           erewrite erase_ren.
           2:{ eapply rscoping_S. }
           2:{ eapply rscoping_comp_S. }
-          ssimpl. reflexivity.
+          rasimpl. reflexivity.
       * (* cbn. destruct_if e'. 2: discriminate. *)
         eapply ext_cterm. intros [].
-        -- ssimpl. cbn. destruct_if e'. 2: discriminate.
+        -- rasimpl. cbn. destruct_if e'. 2: discriminate.
           reflexivity.
-        -- ssimpl. cbn. ssimpl.
+        -- rasimpl. cbn. unfold funcomp.
           erewrite erase_ren.
           2:{ eapply rscoping_S. }
           2:{ eapply rscoping_comp_S. }
-          ssimpl. reflexivity.
+          rasimpl. reflexivity.
     + destruct m. all: try discriminate.
       destruct m0. all: try discriminate.
-      cbn. ssimpl. f_equal. all: f_equal. all: f_equal.
-      * cbn.
+      cbn. rasimpl. f_equal. all: f_equal. all: f_equal.
+      * asimpl. cbn. unfold funcomp. rasimpl.
         eapply ext_cterm. intros [].
-        -- ssimpl. reflexivity.
-        -- ssimpl. cbn. ssimpl.
+        -- rasimpl. reflexivity.
+        -- rasimpl. cbn. unfold funcomp.
           erewrite erase_ren.
           2:{ eapply rscoping_S. }
           2:{ eapply rscoping_comp_S. }
-          ssimpl. rewrite rinstInst'_cterm.
-          eapply ext_cterm. intro x.
-          cbn. ssimpl. reflexivity.
-      * cbn.
+          rasimpl. reflexivity.
+      * asimpl. cbn. unfold funcomp. rasimpl.
         eapply ext_cterm. intros [].
-        -- ssimpl. reflexivity.
-        -- ssimpl. cbn. ssimpl.
+        -- rasimpl. reflexivity.
+        -- rasimpl. cbn. unfold funcomp.
           erewrite erase_ren.
           2:{ eapply rscoping_S. }
           2:{ eapply rscoping_comp_S. }
-          ssimpl. rewrite rinstInst'_cterm.
-          eapply ext_cterm. intro x.
-          cbn. ssimpl. reflexivity.
+          unfold nones.
+          rasimpl. reflexivity.
     + reflexivity.
     + unfold close, cty_lift. ssimpl. cbn.
       destruct_if e'. 1: discriminate.
@@ -446,13 +443,13 @@ Proof.
         -- cbn. ssimpl. erewrite erase_ren.
           2:{ eapply rscoping_S. }
           2:{ eapply rscoping_comp_S. }
-          ssimpl. reflexivity.
+          rasimpl. reflexivity.
       * f_equal. eapply ext_cterm. intros [].
         -- cbn. reflexivity.
         -- cbn. ssimpl. erewrite erase_ren.
           2:{ eapply rscoping_S. }
           2:{ eapply rscoping_comp_S. }
-          ssimpl. reflexivity.
+          rasimpl. reflexivity.
   - cbn.
     erewrite md_subst.
     2:{ eapply sscoping_shift. eassumption. }
@@ -462,15 +459,15 @@ Proof.
       erewrite IHt2.
       2:{ eapply sscoping_shift. eassumption. }
       2:{ eapply sscoping_comp_shift. assumption. }
-      ssimpl. f_equal.
+      rasimpl. f_equal.
       eapply ext_cterm. intros [].
       * cbn. rewrite e0. reflexivity.
       * cbn. ssimpl.
         erewrite erase_ren.
         2:{ eapply rscoping_S. }
         2:{ eapply rscoping_comp_S. }
-        ssimpl. reflexivity.
-    + unfold close. ssimpl.
+        rasimpl. reflexivity.
+    + unfold close. rasimpl.
       erewrite IHt2.
       2:{ eapply sscoping_shift. eassumption. }
       2:{ eapply sscoping_comp_shift. assumption. }
@@ -480,7 +477,7 @@ Proof.
         erewrite erase_ren.
         2:{ eapply rscoping_S. }
         2:{ eapply rscoping_comp_S. }
-        ssimpl. reflexivity.
+        rasimpl. reflexivity.
     + reflexivity.
   - cbn.
     erewrite md_subst. 2,3: eauto.
@@ -534,7 +531,7 @@ Proof.
       erewrite erase_subst.
       2: eapply sscoping_one. 2: eassumption.
       2: eapply sscoping_comp_one.
-      ssimpl. eapply ext_cterm_scoped. 1: eapply erase_scoping.
+      rasimpl. eapply ext_cterm_scoped. 1: eapply erase_scoping.
       intros [| x] ex.
       * cbn. reflexivity.
       * cbn. unfold relv. unfold inscope in ex.
@@ -548,7 +545,7 @@ Proof.
       erewrite erase_subst.
       2: eapply sscoping_one. 2: eassumption.
       2: eapply sscoping_comp_one.
-      ssimpl. eapply ext_cterm_scoped. 1: eapply erase_scoping.
+      rasimpl. eapply ext_cterm_scoped. 1: eapply erase_scoping.
       intros [| x] ex.
       * unfold inscope in ex. cbn in ex.
         rewrite e0 in ex. discriminate.
@@ -769,7 +766,7 @@ Proof.
   eexists. split.
   - eassumption.
   - eapply (f_equal (λ A, ρ ⋅ A)) in eB.
-    revert eB eC. ssimpl. intros eB eC.
+    rasimpl in eB. rasimpl in eC.
     rewrite eB. assumption.
 Qed.
 
@@ -837,7 +834,7 @@ Proof.
     + destruct m. all: try discriminate.
     + destruct m. all: try discriminate.
       destruct mx. all: try discriminate.
-      ssimpl.
+      rasimpl.
       econstructor.
       * econstructor. all: econstructor.
         -- eapply erase_typing_El. 1: eapply IHh1. 2: reflexivity.
@@ -967,7 +964,7 @@ Proof.
       * cbn. f_equal. erewrite erase_subst.
         2: eapply sscoping_one. 2: eassumption.
         2: eapply sscoping_comp_one.
-        ssimpl.
+        rasimpl.
         eapply ext_cterm_scoped. 1: eapply erase_scoping.
         intros [| x] ex.
         -- cbn. reflexivity.
@@ -1082,7 +1079,7 @@ Proof.
         econstructor.
         - eauto.
         - apply cconv_sym. eapply cconv_trans. 1: constructor.
-          cbn. ssimpl. apply cconv_refl.
+          cbn. rasimpl. apply cconv_refl.
         - eapply ccmeta_conv.
           + econstructor. 2: eauto with cc_type.
             econstructor. 1: etype.
@@ -1101,7 +1098,7 @@ Proof.
         econstructor.
         - eauto.
         - apply cconv_sym. eapply cconv_trans. 1: constructor.
-          cbn. ssimpl. apply cconv_refl.
+          cbn. rasimpl. apply cconv_refl.
         - eapply ccmeta_conv.
           + econstructor. 2: eauto with cc_type.
             econstructor. 1: etype.
@@ -1122,7 +1119,7 @@ Proof.
           + etype.
           + cbn. reflexivity.
         - apply cconv_sym. eapply cconv_trans. 1: constructor.
-          cbn. ssimpl. apply cconv_refl.
+          cbn. rasimpl. apply cconv_refl.
         - eapply ccmeta_conv.
           + etype. eapply ccmeta_conv.
             * {
@@ -1136,7 +1133,7 @@ Proof.
           + cbn. reflexivity.
       }
     + eapply cconv_trans. 1: constructor.
-      cbn. ssimpl. apply cconv_refl.
+      cbn. rasimpl. apply cconv_refl.
     + etype. eapply ccmeta_conv.
       * etype.
       * cbn. reflexivity.
@@ -1227,7 +1224,7 @@ Proof.
       eapply cconv_trans. 1: constructor.
       eapply cconv_trans. 1: constructor.
       erewrite erase_ren. 2,3: eauto using rscoping_S, rscoping_comp_S.
-      lhs_ssimpl.
+      rasimpl.
       econstructor. 1: econv.
       constructor.
     }
@@ -1249,18 +1246,16 @@ Proof.
       constructor.
       1:{
         erewrite !erase_ren. 2-5: eauto using rscoping_S, rscoping_comp_S.
-        lhs_ssimpl. rewrite <- rinstInst'_cterm. econv.
+        rasimpl. econv.
       }
       eapply cconv_trans. 1: constructor.
       erewrite !erase_ren. 2-19: eauto using rscoping_S, rscoping_comp_S.
       constructor.
       - constructor. constructor. 2: econv.
-        apply ccmeta_refl. lhs_ssimpl.
-        rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
+        apply ccmeta_refl. rasimpl.
         reflexivity.
       - constructor. constructor. 2: econv.
-        apply ccmeta_refl. lhs_ssimpl.
-        rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
+        apply ccmeta_refl. rasimpl.
         reflexivity.
     }
     2:{
@@ -1271,7 +1266,7 @@ Proof.
       - eapply ccmeta_conv.
         + ertype. 2: reflexivity.
           eapply ccmeta_conv. 1: ertype.
-          cbn. f_equal. f_equal. f_equal. ssimpl. reflexivity.
+          cbn. f_equal. f_equal. f_equal. rasimpl. reflexivity.
         + reflexivity.
       - eapply ccmeta_conv.
         + econstructor.
@@ -1282,7 +1277,7 @@ Proof.
               + cbn. reflexivity.
             - eapply ccmeta_conv.
               + ertype. reflexivity.
-              + cbn. ssimpl. reflexivity.
+              + cbn. rasimpl. reflexivity.
             - eapply ccmeta_conv.
               + ertype.
               + reflexivity.

--- a/theories/Param.v
+++ b/theories/Param.v
@@ -419,8 +419,8 @@ Proof.
   }
   eexists. split.
   - eassumption.
-  - ssimpl. unfold vreg. cbn. ssimpl. eapply extRen_cterm.
-    intro. ssimpl. lia.
+  - rasimpl. unfold vreg. cbn. rasimpl. eapply extRen_cterm.
+    intro. ssimpl. unfold shift. lia.
 Qed.
 
 (** ⟦ Γ ⟧ε is a sub-context of ⟦ Γ ⟧p **)
@@ -817,7 +817,7 @@ Lemma pren_epm_lift :
     pren ρ ⋅ epm_lift t = epm_lift (ρ ⋅ t).
 Proof.
   intros ρ t.
-  unfold epm_lift. ssimpl.
+  unfold epm_lift. rasimpl.
   eapply extRen_cterm. intro x.
   unfold vreg, pren. ssimpl.
   replace (x * 2) with (2 * x) by lia.
@@ -851,12 +851,12 @@ Proof.
     destruct (nth_error Δ n) eqn:e.
     + eapply hρ in e as e'. rewrite e'.
       destruct_if e1.
-      * unfold vreg, pren. ssimpl. f_equal.
+      * unfold vreg, pren. rasimpl. f_equal.
         replace (n * 2) with (2 * n) by lia.
         rewrite PeanoNat.Nat.div2_succ_double.
         rewrite PeanoNat.Nat.odd_succ.
         rewrite PeanoNat.Nat.even_mul. cbn. lia.
-      * unfold pren, vpar. ssimpl. f_equal.
+      * unfold pren, vpar. rasimpl. f_equal.
         replace (n * 2) with (2 * n) by lia.
         rewrite PeanoNat.Nat.div2_double.
         rewrite PeanoNat.Nat.odd_mul. cbn. lia.
@@ -873,60 +873,27 @@ Proof.
     destruct m, m0. all: cbn in *. (* all: try reflexivity. *)
     + f_equal. all: f_equal.
       1:{ rewrite pren_epm_lift. cbn. reflexivity. }
-      1:{ cEl_ren. rewrite <- pren_epm_lift. ssimpl. reflexivity. }
+      1:{ cEl_ren. rewrite <- pren_epm_lift. rasimpl. reflexivity. }
       f_equal. all: f_equal.
-      * ssimpl. reflexivity.
-      * ssimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+      * rasimpl. reflexivity.
+      * rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
         ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
     + f_equal. all: f_equal.
       1:{ rewrite pren_epm_lift. cbn. reflexivity. }
-      1:{ cEl_ren. rewrite <- pren_epm_lift. ssimpl. reflexivity. }
+      1:{ cEl_ren. rewrite <- pren_epm_lift. rasimpl. reflexivity. }
       f_equal. all: f_equal.
-      * ssimpl. reflexivity.
-      * ssimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+      * rasimpl. reflexivity.
+      * rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
         ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
     + f_equal. all: f_equal.
       1:{
         rewrite pren_epm_lift. cbn. f_equal.
         unfold close. ssimpl. reflexivity.
       }
-      1:{ cEl_ren. rewrite <- pren_epm_lift. ssimpl. reflexivity. }
+      1:{ cEl_ren. rewrite <- pren_epm_lift. rasimpl. reflexivity. }
       f_equal. all: f_equal.
-      * ssimpl. reflexivity.
-      * ssimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
-    + f_equal. all: f_equal.
-      1:{
-        rewrite pren_epm_lift. cbn. f_equal.
-        unfold close. ssimpl. reflexivity.
-      }
-      1:{ ssimpl. reflexivity. }
-      f_equal.
-      ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-      ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
-    + f_equal. all: f_equal.
-      1:{ rewrite pren_epm_lift. cbn. reflexivity. }
-      1:{ cEl_ren. rewrite <- pren_epm_lift. ssimpl. reflexivity. }
-      f_equal. all: f_equal.
-      * ssimpl. reflexivity.
-      * ssimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
-    + f_equal. all: f_equal.
-      1:{ rewrite pren_epm_lift. cbn. reflexivity. }
-      1:{ cEl_ren. rewrite <- pren_epm_lift. ssimpl. reflexivity. }
-      f_equal. all: f_equal.
-      * ssimpl. reflexivity.
-      * ssimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
-    + f_equal. all: f_equal.
-      1:{
-        rewrite pren_epm_lift. cbn. f_equal.
-        unfold close. ssimpl. reflexivity.
-      }
-      1:{ cEl_ren. rewrite <- pren_epm_lift. ssimpl. reflexivity. }
-      f_equal. all: f_equal.
-      * ssimpl. reflexivity.
-      * ssimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+      * rasimpl. reflexivity.
+      * rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
         ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
     + f_equal. all: f_equal.
       1:{
@@ -939,17 +906,17 @@ Proof.
       ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
     + f_equal. all: f_equal.
       1:{ rewrite pren_epm_lift. cbn. reflexivity. }
-      1:{ cEl_ren. rewrite <- pren_epm_lift. ssimpl. reflexivity. }
+      1:{ cEl_ren. rewrite <- pren_epm_lift. rasimpl. reflexivity. }
       f_equal. all: f_equal.
-      * ssimpl. reflexivity.
-      * ssimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+      * rasimpl. reflexivity.
+      * rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
         ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
     + f_equal. all: f_equal.
       1:{ rewrite pren_epm_lift. cbn. reflexivity. }
-      1:{ cEl_ren. rewrite <- pren_epm_lift. ssimpl. reflexivity. }
+      1:{ cEl_ren. rewrite <- pren_epm_lift. rasimpl. reflexivity. }
       f_equal. all: f_equal.
-      * ssimpl. reflexivity.
-      * ssimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+      * rasimpl. reflexivity.
+      * rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
         ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
     + f_equal. all: f_equal.
       1:{
@@ -958,34 +925,67 @@ Proof.
       }
       1:{ cEl_ren. rewrite <- pren_epm_lift. ssimpl. reflexivity. }
       f_equal. all: f_equal.
-      * ssimpl. reflexivity.
-      * ssimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+      * rasimpl. reflexivity.
+      * rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
         ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
     + f_equal. all: f_equal.
       1:{
         rewrite pren_epm_lift. cbn. f_equal.
         unfold close. ssimpl. reflexivity.
       }
-      1:{ ssimpl. reflexivity. }
+      1:{ rasimpl. reflexivity. }
       f_equal.
       ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
       ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
     + f_equal. all: f_equal.
       1:{ rewrite pren_epm_lift. cbn. reflexivity. }
-      1:{ ssimpl. reflexivity. }
-      ssimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+      1:{ cEl_ren. rewrite <- pren_epm_lift. rasimpl. reflexivity. }
+      f_equal. all: f_equal.
+      * rasimpl. reflexivity.
+      * rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+        ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
+    + f_equal. all: f_equal.
+      1:{ rewrite pren_epm_lift. cbn. reflexivity. }
+      1:{ cEl_ren. rewrite <- pren_epm_lift. rasimpl. reflexivity. }
+      f_equal. all: f_equal.
+      * rasimpl. reflexivity.
+      * rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+        ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
+    + f_equal. all: f_equal.
+      1:{
+        rewrite pren_epm_lift. cbn. f_equal.
+        unfold close. ssimpl. reflexivity.
+      }
+      1:{ cEl_ren. rewrite <- pren_epm_lift. rasimpl. reflexivity. }
+      f_equal. all: f_equal.
+      * rasimpl. reflexivity.
+      * rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+        ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
+    + f_equal. all: f_equal.
+      1:{
+        rewrite pren_epm_lift. cbn. f_equal.
+        unfold close. ssimpl. reflexivity.
+      }
+      1:{ rasimpl. reflexivity. }
+      f_equal.
+      ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+      ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
+    + f_equal. all: f_equal.
+      1:{ rewrite pren_epm_lift. cbn. reflexivity. }
+      1:{ rasimpl. reflexivity. }
+      rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
       ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
     + f_equal. all: f_equal.
       1:{ rewrite pren_epm_lift. reflexivity. }
-      1:{ ssimpl. reflexivity. }
-      ssimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+      1:{ rasimpl. reflexivity. }
+      rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
       ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. reflexivity.
     + f_equal. all: f_equal.
       1:{ rewrite pren_epm_lift. reflexivity. }
-      1:{ ssimpl. reflexivity. }
-      ssimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+      1:{ rasimpl. reflexivity. }
+      rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
       ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. reflexivity.
-    + f_equal. unfold close. ssimpl.
+    + f_equal. unfold close. rasimpl.
       eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
       ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
   - cbn.
@@ -996,13 +996,13 @@ Proof.
     unfold plam.
     erewrite erase_ren. 2,3: eassumption.
     destruct_ifs. all: mode_eqs.
-    + cbn. unfold close. ssimpl. f_equal.
+    + cbn. unfold close. rasimpl. f_equal.
       eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
       ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
-    + cbn. rewrite pren_epm_lift. ssimpl. f_equal. f_equal.
+    + cbn. rewrite pren_epm_lift. rasimpl. f_equal. f_equal.
       eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
       ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. reflexivity.
-    + cbn. rewrite pren_epm_lift. ssimpl. f_equal. f_equal.
+    + cbn. rewrite pren_epm_lift. rasimpl. f_equal. f_equal.
       eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
       ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. reflexivity.
   - cbn.
@@ -1054,26 +1054,26 @@ Proof.
       erewrite IHt6. 2,3: eassumption.
       rewrite ?pren_epm_lift, ?pren_rpm_lift.
       f_equal. all: f_equal. all: f_equal.
-      2:{ rewrite <- pren_epm_lift. ssimpl. reflexivity. }
-      3:{ ssimpl. reflexivity. }
+      2:{ rewrite <- pren_epm_lift. rasimpl. reflexivity. }
+      3:{ rasimpl. reflexivity. }
       all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       all: f_equal.
-      1:{ ssimpl. reflexivity. }
-      1:{ rewrite <- pren_rpm_lift. ssimpl. reflexivity. }
-      1:{ cEl_ren. rewrite <- pren_rpm_lift. ssimpl. reflexivity. }
-      3:{ ssimpl. reflexivity. }
+      1:{ rasimpl. reflexivity. }
+      1:{ rewrite <- pren_rpm_lift. rasimpl. reflexivity. }
+      1:{ cEl_ren. rewrite <- pren_rpm_lift. rasimpl. reflexivity. }
+      3:{ rasimpl. reflexivity. }
       all: f_equal.
-      3:{ ssimpl. reflexivity. }
-      3:{ rewrite <- pren_rpm_lift. ssimpl. reflexivity. }
+      3:{ rasimpl. reflexivity. }
+      3:{ rewrite <- pren_rpm_lift. rasimpl. reflexivity. }
       all: f_equal.
-      1:{ cEl_ren. rewrite <- pren_epm_lift. ssimpl. reflexivity. }
-      1:{ rewrite <- pren_rpm_lift. ssimpl. reflexivity. }
+      1:{ cEl_ren. rewrite <- pren_epm_lift. rasimpl. reflexivity. }
+      1:{ rewrite <- pren_rpm_lift. rasimpl. reflexivity. }
       all: f_equal.
-      1:{ ssimpl. reflexivity. }
-      2:{ rewrite <- pren_epm_lift. ssimpl. reflexivity. }
+      1:{ rasimpl. reflexivity. }
+      2:{ rewrite <- pren_epm_lift. rasimpl. reflexivity. }
       f_equal. f_equal.
-      ssimpl. reflexivity.
+      rasimpl. reflexivity.
     + unfold pcastTG. cbn.
       erewrite IHt1. 2,3: eassumption.
       erewrite IHt3. 2,3: eassumption.
@@ -1082,26 +1082,26 @@ Proof.
       erewrite IHt6. 2,3: eassumption.
       rewrite ?pren_epm_lift, ?pren_rpm_lift.
       f_equal. all: f_equal. all: f_equal.
-      2:{ rewrite <- pren_epm_lift. ssimpl. reflexivity. }
-      3:{ ssimpl. reflexivity. }
+      2:{ rewrite <- pren_epm_lift. rasimpl. reflexivity. }
+      3:{ rasimpl. reflexivity. }
       all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       all: f_equal.
-      1:{ ssimpl. reflexivity. }
-      1:{ rewrite <- pren_rpm_lift. ssimpl. reflexivity. }
-      1:{ cEl_ren. rewrite <- pren_rpm_lift. ssimpl. reflexivity. }
-      3:{ ssimpl. reflexivity. }
+      1:{ rasimpl. reflexivity. }
+      1:{ rewrite <- pren_rpm_lift. rasimpl. reflexivity. }
+      1:{ cEl_ren. rewrite <- pren_rpm_lift. rasimpl. reflexivity. }
+      3:{ rasimpl. reflexivity. }
       all: f_equal.
-      3:{ ssimpl. reflexivity. }
-      3:{ rewrite <- pren_rpm_lift. ssimpl. reflexivity. }
+      3:{ rasimpl. reflexivity. }
+      3:{ rewrite <- pren_rpm_lift. rasimpl. reflexivity. }
       all: f_equal.
-      1:{ cEl_ren. rewrite <- pren_epm_lift. ssimpl. reflexivity. }
-      1:{ rewrite <- pren_rpm_lift. ssimpl. reflexivity. }
+      1:{ cEl_ren. rewrite <- pren_epm_lift. rasimpl. reflexivity. }
+      1:{ rewrite <- pren_rpm_lift. rasimpl. reflexivity. }
       all: f_equal.
-      1:{ ssimpl. reflexivity. }
-      2:{ rewrite <- pren_epm_lift. ssimpl. reflexivity. }
+      1:{ rasimpl. reflexivity. }
+      2:{ rewrite <- pren_epm_lift. rasimpl. reflexivity. }
       f_equal. f_equal.
-      ssimpl. reflexivity.
+      rasimpl. reflexivity.
     + unfold pcastP. cbn.
       erewrite IHt1. 2,3: eassumption.
       erewrite IHt3. 2,3: eassumption.
@@ -1110,24 +1110,24 @@ Proof.
       erewrite IHt6. 2,3: eassumption.
       rewrite ?pren_epm_lift, ?pren_rpm_lift.
       f_equal. all: f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
-      3:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
+      3:{ rasimpl. reflexivity. }
       all: f_equal.
-      1:{ ssimpl. reflexivity. }
-      1:{ rewrite <- pren_rpm_lift. ssimpl. reflexivity. }
+      1:{ rasimpl. reflexivity. }
+      1:{ rewrite <- pren_rpm_lift. rasimpl. reflexivity. }
       all: f_equal.
-      1:{ cEl_ren. rewrite <- pren_epm_lift. ssimpl. reflexivity. }
-      3:{ ssimpl. reflexivity. }
+      1:{ cEl_ren. rewrite <- pren_epm_lift. rasimpl. reflexivity. }
+      3:{ rasimpl. reflexivity. }
       all: f_equal.
-      3:{ ssimpl. reflexivity. }
-      3:{ rewrite <- pren_rpm_lift. ssimpl. reflexivity. }
+      3:{ rasimpl. reflexivity. }
+      3:{ rewrite <- pren_rpm_lift. rasimpl. reflexivity. }
       all: f_equal.
-      1:{ cEl_ren. rewrite <- pren_epm_lift. ssimpl. reflexivity. }
-      1:{ rewrite <- pren_rpm_lift. ssimpl. reflexivity. }
+      1:{ cEl_ren. rewrite <- pren_epm_lift. rasimpl. reflexivity. }
+      1:{ rewrite <- pren_rpm_lift. rasimpl. reflexivity. }
       all: f_equal.
-      1:{ ssimpl. reflexivity. }
+      1:{ rasimpl. reflexivity. }
       f_equal.
-      ssimpl. reflexivity.
+      rasimpl. reflexivity.
   - cbn. reflexivity.
   - cbn. reflexivity.
   - cbn. reflexivity.
@@ -1141,11 +1141,11 @@ Proof.
       all: f_equal. 1,4: f_equal.
       1,2: f_equal. 1-4: f_equal. 1,2,5-7,10: f_equal.
       2,3,5,6: f_equal. 2,4: f_equal.
-      all: ssimpl. all: reflexivity.
+      all: rasimpl. all: reflexivity.
     + cbn. unfold pmif, plam. cbn. f_equal. f_equal. f_equal.
-      ssimpl. reflexivity.
+      rasimpl. reflexivity.
     + cbn. unfold pmif, plam. cbn. f_equal. f_equal. f_equal.
-      ssimpl. reflexivity.
+      rasimpl. reflexivity.
   - cbn. reflexivity.
   - cbn. reflexivity.
   - cbn. f_equal. eauto.
@@ -1253,35 +1253,35 @@ Proof.
   - ssimpl. erewrite erase_ren.
     2: eapply rscoping_S.
     2: eapply rscoping_comp_S.
-    ssimpl. rewrite <- pren_epm_lift.
-    ssimpl. eapply extRen_cterm.
+    rasimpl. rewrite <- pren_epm_lift.
+    rasimpl. eapply extRen_cterm.
     intro x. unfold shift. change (pren S) with (pren (id >> S)).
-    rewrite pren_comp_S. ssimpl. rewrite pren_id. reflexivity.
+    rewrite pren_comp_S. rasimpl. rewrite pren_id. reflexivity.
   - ssimpl. erewrite param_ren.
     2: eapply rscoping_S.
     2: eapply rscoping_comp_S.
-    ssimpl. eapply extRen_cterm.
+    rasimpl. eapply extRen_cterm.
     intro x. unfold shift. change (pren S) with (pren (id >> S)).
-    rewrite pren_comp_S. ssimpl. rewrite pren_id. reflexivity.
+    rewrite pren_comp_S. rasimpl. rewrite pren_id. reflexivity.
   - ssimpl. erewrite revive_ren.
     2: eapply rscoping_S.
     2: eapply rscoping_comp_S.
-    ssimpl. rewrite <- pren_rpm_lift.
+    rasimpl. rewrite <- pren_rpm_lift.
     eapply extRen_cterm.
     intro x. unfold shift. change (pren S) with (pren (id >> S)).
-    rewrite pren_comp_S. ssimpl. rewrite pren_id. reflexivity.
+    rewrite pren_comp_S. rasimpl. rewrite pren_id. reflexivity.
   - ssimpl. erewrite param_ren.
     2: eapply rscoping_S.
     2: eapply rscoping_comp_S.
-    ssimpl. eapply extRen_cterm.
+    rasimpl. eapply extRen_cterm.
     intro x. unfold shift. change (pren S) with (pren (id >> S)).
-    rewrite pren_comp_S. ssimpl. rewrite pren_id. reflexivity.
+    rewrite pren_comp_S. rasimpl. rewrite pren_id. reflexivity.
   - ssimpl. erewrite param_ren.
     2: eapply rscoping_S.
     2: eapply rscoping_comp_S.
-    ssimpl. eapply extRen_cterm.
+    rasimpl. eapply extRen_cterm.
     intro x. unfold shift. change (pren S) with (pren (id >> S)).
-    rewrite pren_comp_S. ssimpl. rewrite pren_id. reflexivity.
+    rewrite pren_comp_S. rasimpl. rewrite pren_id. reflexivity.
   - reflexivity.
 Qed.
 
@@ -1310,7 +1310,7 @@ Lemma psubst_rpm_lift :
     (rpm_lift t) <[ psubst Δ Γ σ ] = rpm_lift (t <[ rev_subst Δ Γ σ ]).
 Proof.
   intros Γ Δ σ t ht.
-  unfold rpm_lift. ssimpl.
+  unfold rpm_lift. rasimpl.
   eapply ext_cterm_scoped. 1: eassumption.
   intros x hx.
   ssimpl. unfold psubst. rewrite div2_vreg.
@@ -1358,44 +1358,44 @@ Proof.
     erewrite <- psubst_epm_lift. 2:{ econstructor. eapply erase_scoping. }
     destruct m, m0. all: cbn in *.
     + f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       1: rewrite psubst_epm_lift.
       2:{ unshelve typeclasses eauto with cc_scope shelvedb. all: reflexivity. }
       all: f_equal. all: cbn. all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       2:{
-        ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
+        rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+        ssimpl. rewrite psubst_SS. rasimpl. reflexivity.
       }
       f_equal. all: f_equal. all: f_equal.
-      all: eapply ext_cterm. all: ssimpl. all: intros [].
+      all: eapply ext_cterm. all: rasimpl. all: intros [].
       all: cbn. 1,3: reflexivity.
       all: ssimpl.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
     + f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       1: rewrite psubst_epm_lift.
       2:{ unshelve typeclasses eauto with cc_scope shelvedb. all: reflexivity. }
       all: f_equal. all: cbn. all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       2:{
-        ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
+        rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+        ssimpl. rewrite psubst_SS. rasimpl. reflexivity.
       }
       f_equal. all: f_equal. all: f_equal.
-      all: eapply ext_cterm. all: ssimpl. all: intros [].
+      all: eapply ext_cterm. all: rasimpl. all: intros [].
       all: cbn. 1,3: reflexivity.
       all: ssimpl.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
     + f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       1: rewrite psubst_epm_lift.
       2:{ unshelve typeclasses eauto with cc_scope shelvedb. all: reflexivity. }
       all: f_equal. all: cbn. all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       2:{
-        ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
+        rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+        ssimpl. rewrite psubst_SS. rasimpl. reflexivity.
       }
       unfold cty_lift. f_equal. all: f_equal.
       all: unfold close. all: ssimpl.
@@ -1403,15 +1403,15 @@ Proof.
       all: cbn. 1,3: reflexivity.
       all: ssimpl.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
-      all: ssimpl. all: reflexivity.
+      all: rasimpl. all: reflexivity.
     + f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       1: rewrite psubst_epm_lift.
       2:{ unshelve typeclasses eauto with cc_scope shelvedb. all: reflexivity. }
       all: f_equal.
       2:{
         ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. ssimpl.
+        ssimpl. rewrite psubst_SS. rasimpl.
         rewrite rinstInst'_cterm. reflexivity.
       }
       cbn. unfold cty_lift. f_equal. f_equal. all: f_equal.
@@ -1420,47 +1420,47 @@ Proof.
       all: cbn. 1,3: reflexivity.
       all: ssimpl.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
-      all: ssimpl. all: reflexivity.
+      all: rasimpl. all: reflexivity.
     + f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       1: rewrite psubst_epm_lift.
       2:{ unshelve typeclasses eauto with cc_scope shelvedb. all: reflexivity. }
       all: f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       2:{
-        ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
+        rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+        ssimpl. rewrite psubst_SS. rasimpl. reflexivity.
       }
       cbn. f_equal. f_equal. all: f_equal. all: f_equal.
-      all: ssimpl.
+      all: rasimpl.
       all: eapply ext_cterm. all: intros [].
       all: cbn. 1,3: reflexivity.
       all: ssimpl.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
     + f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       1: rewrite psubst_epm_lift.
       2:{ unshelve typeclasses eauto with cc_scope shelvedb. all: reflexivity. }
       all: f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       2:{
-        ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
+        rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+        ssimpl. rewrite psubst_SS. rasimpl. reflexivity.
       }
       cbn. f_equal. f_equal. all: f_equal. all: f_equal.
-      all: ssimpl.
+      all: rasimpl.
       all: eapply ext_cterm. all: intros [].
       all: cbn. 1,3: reflexivity.
       all: ssimpl.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
     + f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       1: rewrite psubst_epm_lift.
       2:{ unshelve typeclasses eauto with cc_scope shelvedb. all: reflexivity. }
       all: f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       2:{
-        ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+        rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
         ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
       }
       cbn. unfold cty_lift. f_equal. f_equal. all: f_equal. all: unfold close.
@@ -1469,15 +1469,15 @@ Proof.
       all: cbn. 1,3: reflexivity.
       all: ssimpl.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
-      all: ssimpl. all: reflexivity.
+      all: rasimpl. all: reflexivity.
     + f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       1: rewrite psubst_epm_lift.
       2:{ unshelve typeclasses eauto with cc_scope shelvedb. all: reflexivity. }
       all: f_equal.
       2:{
         ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. ssimpl.
+        ssimpl. rewrite psubst_SS. rasimpl.
         erewrite rinstInst'_cterm. reflexivity.
       }
       cbn. unfold cty_lift. f_equal. f_equal. all: f_equal. all: unfold close.
@@ -1486,15 +1486,47 @@ Proof.
       all: cbn. 1,3: reflexivity.
       all: ssimpl.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
-      all: ssimpl. all: reflexivity.
+      all: rasimpl. all: reflexivity.
     + f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       1: rewrite psubst_epm_lift.
       2:{ unshelve typeclasses eauto with cc_scope shelvedb. all: reflexivity. }
       all: f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       2:{
-        ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+        rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+        ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
+      }
+      cbn. f_equal. f_equal. all: f_equal. all: f_equal.
+      all: rasimpl.
+      all: eapply ext_cterm. all: intros [].
+      all: cbn. 1,3: reflexivity.
+      all: ssimpl.
+      all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
+    + f_equal. all: f_equal.
+      2:{ rasimpl. reflexivity. }
+      1: rewrite psubst_epm_lift.
+      2:{ unshelve typeclasses eauto with cc_scope shelvedb. all: reflexivity. }
+      all: f_equal. all: f_equal.
+      2:{ rasimpl. reflexivity. }
+      2:{
+        rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+        ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
+      }
+      cbn. f_equal. f_equal. all: f_equal. all: f_equal.
+      all: rasimpl.
+      all: eapply ext_cterm. all: intros [].
+      all: cbn. 1,3: reflexivity.
+      all: ssimpl.
+      all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
+    + f_equal. all: f_equal.
+      2:{ rasimpl. reflexivity. }
+      1: rewrite psubst_epm_lift.
+      2:{ unshelve typeclasses eauto with cc_scope shelvedb. all: reflexivity. }
+      all: f_equal. all: f_equal.
+      2:{ rasimpl. reflexivity. }
+      2:{
+        rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
         ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
       }
       cbn. f_equal. f_equal. all: f_equal. all: f_equal.
@@ -1503,49 +1535,17 @@ Proof.
       all: cbn. 1,3: reflexivity.
       all: ssimpl.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
-    + f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
-      1: rewrite psubst_epm_lift.
-      2:{ unshelve typeclasses eauto with cc_scope shelvedb. all: reflexivity. }
-      all: f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
-      2:{
-        ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
-      }
-      cbn. f_equal. f_equal. all: f_equal. all: f_equal.
-      all: ssimpl.
-      all: eapply ext_cterm. all: intros [].
-      all: cbn. 1,3: reflexivity.
-      all: ssimpl.
-      all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
-    + f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
-      1: rewrite psubst_epm_lift.
-      2:{ unshelve typeclasses eauto with cc_scope shelvedb. all: reflexivity. }
-      all: f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
-      2:{
-        ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
-      }
-      cbn. f_equal. f_equal. all: f_equal. all: f_equal.
-      all: ssimpl.
-      all: eapply ext_cterm. all: intros [].
-      all: cbn. 1,3: reflexivity.
-      all: ssimpl.
-      all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
-      all: ssimpl.
+      all: rasimpl.
       * rewrite rinstInst'_cterm. reflexivity.
       * rewrite rinstInst'_cterm. reflexivity.
     + f_equal. all: f_equal.
-      2:{ ssimpl. reflexivity. }
+      2:{ rasimpl. reflexivity. }
       1: rewrite psubst_epm_lift.
       2:{ unshelve typeclasses eauto with cc_scope shelvedb. all: reflexivity. }
       all: f_equal.
       2:{
         ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. ssimpl.
+        ssimpl. rewrite psubst_SS. rasimpl.
         erewrite rinstInst'_cterm. reflexivity.
       }
       cbn. unfold cty_lift. f_equal. f_equal. all: f_equal. all: unfold close.
@@ -1554,22 +1554,22 @@ Proof.
       all: cbn. 1,3: reflexivity.
       all: ssimpl.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
-      all: ssimpl. all: reflexivity.
+      all: rasimpl. all: reflexivity.
     + f_equal. all: f_equal. 1: f_equal.
-      * ssimpl. reflexivity.
-      * ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+      * rasimpl. reflexivity.
+      * rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
         ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
     + f_equal. all: f_equal. 1: f_equal.
-      * ssimpl. reflexivity.
-      * ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+      * rasimpl. reflexivity.
+      * rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
         ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
     + f_equal. all: f_equal. 1: f_equal.
-      * ssimpl. reflexivity.
-      * ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+      * rasimpl. reflexivity.
+      * rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
         ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
     + f_equal. unfold close.
-      ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-      ssimpl. rewrite psubst_SS. ssimpl.
+      rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+      ssimpl. rewrite psubst_SS. rasimpl.
       rewrite rinstInst'_cterm. reflexivity.
   - cbn.
     erewrite IHt1. 2,3: eassumption.
@@ -1580,24 +1580,24 @@ Proof.
     change (cEl (?t <[ ?σ ])) with ((cEl t) <[ σ ]).
     erewrite <- psubst_epm_lift. 2:{ econstructor. eapply erase_scoping. }
     destruct_ifs. all: mode_eqs.
-    + cbn. f_equal. unfold close. ssimpl.
+    + cbn. f_equal. unfold close. rasimpl.
       eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-      ssimpl. rewrite psubst_SS. ssimpl.
+      ssimpl. rewrite psubst_SS. rasimpl.
       erewrite rinstInst'_cterm. reflexivity.
     + cbn. f_equal. unfold plam. f_equal. f_equal.
-      * ssimpl. reflexivity.
-      * ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        rewrite psubst_SS. ssimpl. reflexivity.
+      * rasimpl. reflexivity.
+      * rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+        rewrite psubst_SS. rasimpl. reflexivity.
     + cbn. unfold plam. f_equal. f_equal.
-      * ssimpl. reflexivity.
-      * ssimpl. eapply ext_cterm. intros [| []]. all: cbn.
+      * rasimpl. reflexivity.
+      * rasimpl. eapply ext_cterm. intros [| []]. all: cbn.
         --- destruct_ifs. all: mode_eqs. all: try discriminate.
           all: try reflexivity.
           destruct m. all: discriminate.
         --- destruct_ifs. all: mode_eqs. all: try discriminate.
           all: try reflexivity.
           destruct m. all: discriminate.
-        --- rewrite psubst_SS. ssimpl. reflexivity.
+        --- rewrite psubst_SS. rasimpl. reflexivity.
   - cbn.
     erewrite md_subst. 2,3: eassumption.
     erewrite IHt1. 2,3: eassumption.
@@ -1661,9 +1661,9 @@ Proof.
     2:{ econstructor. eapply erase_scoping. }
     destruct md eqn:e.
     + reflexivity.
-    + unfold pcastTG. cbn. ssimpl. reflexivity.
-    + unfold pcastTG. cbn. ssimpl. reflexivity.
-    + unfold pcastP. cbn. ssimpl. reflexivity.
+    + unfold pcastTG. cbn. rasimpl. reflexivity.
+    + unfold pcastTG. cbn. rasimpl. reflexivity.
+    + unfold pcastP. cbn. rasimpl. reflexivity.
   - cbn. reflexivity.
   - cbn. reflexivity.
   - cbn. reflexivity.
@@ -1677,11 +1677,11 @@ Proof.
     + unfold pmifK. unfold perif. cbn. f_equal. f_equal. all: f_equal.
       1,4: f_equal. 1,2: f_equal. 1-4: f_equal. 1,2,5-7,10: f_equal.
       2,3,5,6: f_equal. 2,4: f_equal.
-      all: ssimpl. all: reflexivity.
+      all: rasimpl. all: reflexivity.
     + unfold pmif, plam. cbn. f_equal. f_equal. f_equal.
-      ssimpl. reflexivity.
+      rasimpl. reflexivity.
     + unfold pmif, plam. cbn. f_equal. f_equal. f_equal.
-      ssimpl. reflexivity.
+      rasimpl. reflexivity.
     + reflexivity.
   - cbn. reflexivity.
   - cbn. reflexivity.
@@ -1938,11 +1938,11 @@ Proof.
       1:{ constructor. 2: apply cconv_refl. constructor. }
       cbn.
       eapply cconv_trans. 1: constructor.
-      ssimpl. apply ccmeta_refl.
+      rasimpl. apply ccmeta_refl.
       erewrite param_subst.
       2:{ eapply sscoping_one. eassumption. }
       2: eapply sscoping_comp_one.
-      ssimpl. eapply ext_cterm_scoped.
+      rasimpl. eapply ext_cterm_scoped.
       1:{ eapply param_scoping. eassumption. }
       (* The following we do basically four times, but we don't know how
         to factorise.
@@ -1960,10 +1960,10 @@ Proof.
         1:{ rewrite en in eodd. rewrite odd_vpar in eodd. discriminate. }
         destruct (isProp mx) eqn:e2. 1: discriminate.
         destruct (isKind mx) eqn:e3. all: mode_eqs.
-        -- cbn. f_equal. assumption.
+        -- cbn. rasimpl. f_equal. assumption.
         -- destruct mx. all: try discriminate.
-          ++ cbn. f_equal. assumption.
-          ++ cbn. f_equal. assumption.
+          ++ cbn. ssimpl. f_equal. assumption.
+          ++ cbn. ssimpl. f_equal. assumption.
       * set (p := Nat.div2 n) in *.
         rewrite en in hx. rewrite nth_error_param_vreg in hx.
         destruct nth_error as [mx|] eqn:e1. 2: discriminate.
@@ -1973,7 +1973,7 @@ Proof.
         destruct PeanoNat.Nat.odd eqn:eodd.
         2:{ rewrite en in eodd. rewrite odd_vreg in eodd. discriminate. }
         destruct (isProp mx) eqn:e2.
-        -- mode_eqs. cbn. f_equal. assumption.
+        -- mode_eqs. cbn. ssimpl. f_equal. assumption.
         -- unfold relv, ghv. rewrite e1.
           destruct_ifs.
           ++ rewrite en. reflexivity.
@@ -1985,11 +1985,11 @@ Proof.
       1:{ constructor. 2: apply cconv_refl. constructor. }
       cbn.
       eapply cconv_trans. 1: constructor.
-      ssimpl. apply ccmeta_refl.
+      rasimpl. apply ccmeta_refl.
       erewrite param_subst.
       2:{ eapply sscoping_one. eassumption. }
       2: eapply sscoping_comp_one.
-      ssimpl. eapply ext_cterm_scoped.
+      rasimpl. eapply ext_cterm_scoped.
       1:{ eapply param_scoping. eassumption. }
       (* Basically same as above, is there a nice lemma to state? *)
       intros [| []] hx. all: cbn. 1,2: reflexivity.
@@ -2006,10 +2006,10 @@ Proof.
         1:{ rewrite en in eodd. rewrite odd_vpar in eodd. discriminate. }
         destruct (isProp mx) eqn:e2. 1: discriminate.
         destruct (isKind mx) eqn:e3. all: mode_eqs.
-        -- cbn. f_equal. assumption.
+        -- cbn. ssimpl. f_equal. assumption.
         -- destruct mx. all: try discriminate.
-          ++ cbn. f_equal. assumption.
-          ++ cbn. f_equal. assumption.
+          ++ cbn. ssimpl. f_equal. assumption.
+          ++ cbn. ssimpl. f_equal. assumption.
       * set (p := Nat.div2 n) in *.
         rewrite en in hx. rewrite nth_error_param_vreg in hx.
         destruct nth_error as [mx|] eqn:emx. 2: discriminate.
@@ -2019,7 +2019,7 @@ Proof.
         destruct PeanoNat.Nat.odd eqn:eodd.
         2:{ rewrite en in eodd. rewrite odd_vreg in eodd. discriminate. }
         destruct (isProp mx) eqn:e2.
-        -- mode_eqs. cbn. f_equal. assumption.
+        -- mode_eqs. cbn. ssimpl. f_equal. assumption.
         -- unfold relv, ghv. rewrite emx.
           destruct_ifs.
           ++ rewrite en. reflexivity.
@@ -2029,11 +2029,11 @@ Proof.
       1:{ constructor. 2: apply cconv_refl. constructor. }
       cbn.
       eapply cconv_trans. 1: constructor.
-      ssimpl. apply ccmeta_refl.
+      rasimpl. apply ccmeta_refl.
       erewrite param_subst.
       2:{ eapply sscoping_one. eassumption. }
       2: eapply sscoping_comp_one.
-      ssimpl. eapply ext_cterm_scoped.
+      rasimpl. eapply ext_cterm_scoped.
       1:{ eapply param_scoping. eassumption. }
       (* Basically same as above, is there a nice lemma to state? *)
       intros [| []] hx. all: cbn. 1,2: reflexivity.
@@ -2050,10 +2050,10 @@ Proof.
         1:{ rewrite en in eodd. rewrite odd_vpar in eodd. discriminate. }
         destruct (isProp mx) eqn:e3. 1: discriminate.
         destruct (isKind mx) eqn:e4. all: mode_eqs.
-        -- cbn. f_equal. assumption.
+        -- cbn. ssimpl. f_equal. assumption.
         -- destruct mx. all: try discriminate.
-          ++ cbn. f_equal. assumption.
-          ++ cbn. f_equal. assumption.
+          ++ cbn. ssimpl. f_equal. assumption.
+          ++ cbn. ssimpl. f_equal. assumption.
       * set (p := Nat.div2 n) in *.
         rewrite en in hx. rewrite nth_error_param_vreg in hx.
         destruct nth_error as [mx|] eqn:emx. 2: discriminate.
@@ -2063,18 +2063,18 @@ Proof.
         destruct PeanoNat.Nat.odd eqn:eodd.
         2:{ rewrite en in eodd. rewrite odd_vreg in eodd. discriminate. }
         destruct (isProp mx) eqn:e3.
-        -- mode_eqs. cbn. f_equal. assumption.
+        -- mode_eqs. cbn. ssimpl. f_equal. assumption.
         -- unfold relv, ghv. rewrite emx.
           destruct_ifs.
           ++ rewrite en. reflexivity.
           ++ rewrite en. reflexivity.
           ++ destruct mx. all: discriminate.
     + eapply cconv_trans. 1: constructor.
-      unfold close. ssimpl. apply ccmeta_refl.
+      unfold close. rasimpl. apply ccmeta_refl.
       erewrite param_subst.
       2:{ eapply sscoping_one. eassumption. }
       2: eapply sscoping_comp_one.
-      ssimpl. eapply ext_cterm_scoped.
+      rasimpl. eapply ext_cterm_scoped.
       1:{ eapply param_scoping. eassumption. }
       (* Basically same as above, is there a nice lemma to state? *)
       intros [| []] hx. all: cbn. 1,2: reflexivity.
@@ -2091,10 +2091,10 @@ Proof.
         1:{ rewrite en in eodd. rewrite odd_vpar in eodd. discriminate. }
         destruct (isProp mx) eqn:e3. 1: discriminate.
         destruct (isKind mx) eqn:e4. all: mode_eqs.
-        -- cbn. f_equal. assumption.
+        -- cbn. ssimpl. f_equal. assumption.
         -- destruct mx. all: try discriminate.
-          ++ cbn. f_equal. assumption.
-          ++ cbn. f_equal. assumption.
+          ++ cbn. ssimpl. f_equal. assumption.
+          ++ cbn. ssimpl. f_equal. assumption.
       * set (p := Nat.div2 n) in *.
         rewrite en in hx. rewrite nth_error_param_vreg in hx.
         destruct nth_error as [mx|] eqn:emx. 2: discriminate.
@@ -2104,7 +2104,7 @@ Proof.
         destruct PeanoNat.Nat.odd eqn:eodd.
         2:{ rewrite en in eodd. rewrite odd_vreg in eodd. discriminate. }
         destruct (isProp mx) eqn:e3.
-        -- mode_eqs. cbn. f_equal. assumption.
+        -- mode_eqs. cbn. ssimpl. f_equal. assumption.
         -- unfold relv, ghv. rewrite emx.
           destruct_ifs.
           ++ rewrite en. reflexivity.
@@ -2128,7 +2128,7 @@ Proof.
         constructor.
       }
       eapply cconv_trans. 1: constructor.
-      ssimpl. econv.
+      rasimpl. econv.
     + unfold pmif. constructor.
     + unfold pmif. constructor.
     + constructor.
@@ -2140,7 +2140,7 @@ Proof.
         constructor.
       }
       eapply cconv_trans. 1: constructor.
-      ssimpl. econv.
+      rasimpl. econv.
     + unfold pmif. constructor.
     + unfold pmif. constructor.
     + constructor.
@@ -2307,17 +2307,17 @@ Proof.
       all: eauto using crtyping_S.
       cbn. eapply crtyping_shift_eq.
       * apply crtyping_shift. apply crtyping_S.
-      * cbn. f_equal. ssimpl. reflexivity.
+      * cbn. f_equal. rasimpl. reflexivity.
     + econv. all: try reflexivity.
       all: eauto using crtyping_S.
       cbn. eapply crtyping_shift_eq.
       * apply crtyping_shift. apply crtyping_S.
-      * cbn. f_equal. ssimpl. reflexivity.
+      * cbn. f_equal. rasimpl. reflexivity.
     + econv. all: try reflexivity.
       all: eauto using crtyping_S, cstyping_one_none.
       cbn. eapply crtyping_shift_eq.
       * apply crtyping_shift. apply crtyping_S.
-      * cbn. f_equal. ssimpl. reflexivity.
+      * cbn. f_equal. rasimpl. reflexivity.
     + econv. all: try reflexivity.
       all: eauto using crtyping_S, cstyping_one_none.
       * cbn. apply crtyping_shift. apply crtyping_S.
@@ -2326,17 +2326,17 @@ Proof.
       all: eauto using crtyping_S.
       cbn. eapply crtyping_shift_eq.
       * apply crtyping_shift. apply crtyping_S.
-      * cbn. f_equal. ssimpl. reflexivity.
+      * cbn. f_equal. rasimpl. reflexivity.
     + econv. all: try reflexivity.
       all: eauto using crtyping_S.
       cbn. eapply crtyping_shift_eq.
       * apply crtyping_shift. apply crtyping_S.
-      * cbn. f_equal. ssimpl. reflexivity.
+      * cbn. f_equal. rasimpl. reflexivity.
     + econv. all: try reflexivity.
       all: eauto using crtyping_S, cstyping_one_none.
       cbn. eapply crtyping_shift_eq.
       * apply crtyping_shift. apply crtyping_S.
-      * cbn. f_equal. ssimpl. reflexivity.
+      * cbn. f_equal. rasimpl. reflexivity.
     + econv. all: try reflexivity.
       all: eauto using crtyping_S, cstyping_one_none.
       * apply crtyping_shift. apply crtyping_S.
@@ -2345,18 +2345,18 @@ Proof.
       all: eauto using crtyping_S.
       cbn. eapply crtyping_shift_eq.
       * apply crtyping_shift. apply crtyping_S.
-      * cbn. f_equal. ssimpl. reflexivity.
+      * cbn. f_equal. rasimpl. reflexivity.
     + econv. all: try reflexivity.
       all: eauto using crtyping_S.
       cbn. eapply crtyping_shift_eq.
       * apply crtyping_shift. apply crtyping_S.
-      * cbn. f_equal. ssimpl. reflexivity.
+      * cbn. f_equal. rasimpl. reflexivity.
     + econv. all: try reflexivity.
       all: eauto using crtyping_S, cstyping_one_none.
       * eapply cstyping_nones.
       * cbn. eapply crtyping_shift_eq.
         -- apply crtyping_shift. apply crtyping_S.
-        -- cbn. f_equal. ssimpl. reflexivity.
+        -- cbn. f_equal. rasimpl. reflexivity.
     + econv. all: try reflexivity.
       all: eauto using crtyping_S, cstyping_one_none.
       * apply crtyping_shift. apply crtyping_S.
@@ -2452,12 +2452,12 @@ Proof.
       * {
         eapply crtyping_shift_eq.
         - eapply crtyping_shift. apply crtyping_S.
-        - f_equal. f_equal. f_equal. cbn. ssimpl. reflexivity.
+        - f_equal. f_equal. f_equal. cbn. rasimpl. reflexivity.
       }
       * {
         eapply crtyping_shift_eq.
         - eapply crtyping_shift. apply crtyping_S.
-        - f_equal. f_equal. f_equal. cbn. ssimpl. reflexivity.
+        - f_equal. f_equal. f_equal. cbn. rasimpl. reflexivity.
       }
 Qed.
 
@@ -2999,8 +2999,8 @@ Lemma type_pcastTG :
     Γ ⊢ᶜ pcastTG Ae AP uv vv vP eP PP te tP : capp (capp (capp PP vv) vP) te.
 Proof.
   intros Γ i Ae AP uv uP vv vP eP Pe PP te tP. intros.
-  unfold pcastTG. cbn. ssimpl.
-  change (λ n, S (S (S n))) with (S >> S >> S). ssimpl.
+  unfold pcastTG. cbn. rasimpl.
+  change (λ n, S (S (S n))) with (S >> S >> S). rasimpl.
   econstructor.
   - ertype.
     + eapply ccmeta_conv.
@@ -3009,9 +3009,9 @@ Proof.
         eapply ccmeta_conv.
         - ertype. eapply ccmeta_conv.
           + ertype. eapply ccmeta_conv. 1: ertype.
-            cbn. lhs_ssimpl. reflexivity.
-          + cbn. lhs_ssimpl. rewrite !rinstInst'_cterm. reflexivity.
-        - cbn. lhs_ssimpl. rewrite rinstInst'_cterm. reflexivity.
+            cbn. rasimpl. reflexivity.
+          + cbn. rasimpl. rewrite !rinstInst'_cterm. reflexivity.
+        - cbn. rasimpl. rewrite rinstInst'_cterm. reflexivity.
       }
       * cbn. reflexivity.
     + econstructor.
@@ -3019,7 +3019,7 @@ Proof.
         ertype. econstructor.
         - ertype.
           + eapply ccmeta_conv. 1: ertype.
-            cbn. lhs_ssimpl. reflexivity.
+            cbn. rasimpl. reflexivity.
           + eapply ccmeta_conv. 1: ertype.
             cbn. reflexivity.
           + eapply ccmeta_conv.
@@ -3028,25 +3028,24 @@ Proof.
               - eapply ccmeta_conv. 1: ertype.
                 cbn. reflexivity.
               - eapply ccmeta_conv. 1: ertype.
-                cbn. ssimpl. reflexivity.
+                cbn. rasimpl. reflexivity.
               - eapply ccmeta_conv.
                 + ertype. eapply ccmeta_conv. 1: ertype.
-                  cbn. f_equal. ssimpl. reflexivity.
+                  cbn. f_equal. rasimpl. reflexivity.
                 + cbn. reflexivity.
               - eapply ccmeta_conv.
                 + ertype. eapply ccmeta_conv.
                   * {
                     ertype. eapply ccmeta_conv.
                     - ertype. eapply ccmeta_conv. 1: ertype.
-                      cbn. lhs_ssimpl. f_equal. ssimpl. reflexivity.
-                    - cbn. lhs_ssimpl. f_equal. ssimpl.
+                      cbn. lhs_ssimpl. f_equal. rasimpl. reflexivity.
+                    - cbn. lhs_ssimpl. f_equal. rasimpl.
                       rewrite rinstInst'_cterm. reflexivity.
                   }
-                  * cbn. lhs_ssimpl. f_equal.
-                    rewrite rinstInst'_cterm. reflexivity.
+                  * cbn. rasimpl. reflexivity.
                 + cbn. reflexivity.
             }
-            * cbn. f_equal. ssimpl. reflexivity.
+            * cbn. f_equal. rasimpl. reflexivity.
           + econstructor.
             * {
               ertype. eapply ccmeta_conv.
@@ -3059,12 +3058,11 @@ Proof.
                 econstructor. 2: econv.
                 constructor.
               }
-              cbn. ssimpl. eapply cconv_trans. 1: constructor.
-              cbn. ssimpl. rewrite !rinstInst'_cterm. ssimpl. econv.
+              cbn. rasimpl. eapply cconv_trans. 1: constructor.
+              cbn. rasimpl. rewrite !rinstInst'_cterm. rasimpl. econv.
               apply cconv_irr.
               -- escope. reflexivity.
-              -- rewrite <- funcomp_assoc. rewrite <- !rinstInst'_cterm. cbn.
-                eapply cscoping_ren.
+              -- eapply cscoping_ren.
                 1:{ eapply crscoping_comp. all: apply crscoping_S. }
                 assumption.
             * {
@@ -3078,26 +3076,24 @@ Proof.
                     - eapply ccmeta_conv. 1: ertype.
                       cbn. reflexivity.
                     - eapply ccmeta_conv. 1: ertype.
-                      cbn. ssimpl. reflexivity.
+                      cbn. rasimpl. reflexivity.
                     - eapply ccmeta_conv.
                       + ertype. eapply ccmeta_conv. 1: ertype.
-                        cbn. f_equal. ssimpl. reflexivity.
+                        cbn. f_equal. rasimpl. reflexivity.
                       + cbn. reflexivity.
                     - eapply ccmeta_conv.
                       + ertype. eapply ccmeta_conv.
                         * {
                           ertype. eapply ccmeta_conv.
                           - ertype. eapply ccmeta_conv. 1: ertype.
-                            cbn. lhs_ssimpl. f_equal. ssimpl. reflexivity.
-                          - cbn. lhs_ssimpl. f_equal. ssimpl.
+                            cbn. lhs_ssimpl. f_equal. rasimpl. reflexivity.
+                          - cbn. lhs_ssimpl. f_equal. rasimpl.
                             rewrite rinstInst'_cterm. reflexivity.
                         }
-                        * cbn. lhs_ssimpl. rewrite rinstInst'_cterm.
-                          reflexivity.
+                        * cbn. rasimpl. reflexivity.
                       + cbn. reflexivity.
                   }
-                  * cbn. lhs_ssimpl. f_equal.
-                    rewrite <- !rinstInst'_cterm. reflexivity.
+                  * cbn. rasimpl. reflexivity.
                 + eapply ccmeta_conv. 1: ertype.
                   cbn. reflexivity.
               - cbn. reflexivity.
@@ -3118,19 +3114,17 @@ Proof.
               ertype. eapply ccmeta_conv.
               - ertype. eapply ccmeta_conv.
                 + ertype. eapply ccmeta_conv. 1: ertype.
-                  cbn. lhs_ssimpl. reflexivity.
-                + cbn. lhs_ssimpl. f_equal. ssimpl.
-                  rewrite !rinstInst'_cterm. reflexivity.
+                  cbn. rasimpl. reflexivity.
+                + cbn. rasimpl. reflexivity.
               - cbn. lhs_ssimpl. rewrite <- funcomp_assoc.
                 rewrite <- !rinstInst'_cterm. reflexivity.
             }
             * cbn. reflexivity.
       }
-      * cbn. ssimpl. apply cconv_sym. eapply cconv_trans. 1: constructor.
-        cbn. ssimpl. econv.
-        rewrite rinstInst'_cterm. econv.
+      * cbn. rasimpl. apply cconv_sym. eapply cconv_trans. 1: constructor.
+        cbn. rasimpl. econv.
       * {
-        cbn. tm_ssimpl. eapply ccmeta_conv.
+        cbn. rasimpl. eapply ccmeta_conv.
         - ertype.
           + eapply ccmeta_conv. 1: ertype.
             cbn. reflexivity.
@@ -3138,12 +3132,10 @@ Proof.
             * {
               ertype. eapply ccmeta_conv.
               - ertype. eapply ccmeta_conv. 1: ertype.
-                cbn. lhs_ssimpl. reflexivity.
-              - cbn. lhs_ssimpl. f_equal.
-                rewrite !rinstInst'_cterm. reflexivity.
+                cbn. rasimpl. reflexivity.
+              - cbn. rasimpl. reflexivity.
             }
-            * cbn. lhs_ssimpl. f_equal.
-              rewrite rinstInst'_cterm. reflexivity.
+            * cbn. rasimpl. reflexivity.
           + eapply ccmeta_conv. 1: ertype.
             cbn. reflexivity.
           + eapply ccmeta_conv. 1: ertype.
@@ -3151,12 +3143,12 @@ Proof.
         - cbn. reflexivity.
       }
   - eapply cconv_trans. 1: constructor.
-    cbn. ssimpl. econv.
+    cbn. rasimpl. econv.
   - eapply ccmeta_conv.
     + ertype. eapply ccmeta_conv.
       * ertype. eapply ccmeta_conv. 1: ertype.
-        cbn. lhs_ssimpl. reflexivity.
-      * cbn. lhs_ssimpl. reflexivity.
+        cbn. rasimpl. reflexivity.
+      * cbn. rasimpl. reflexivity.
     + cbn. reflexivity.
 Qed.
 
@@ -3263,7 +3255,7 @@ Proof.
     + econstructor.
       * etype.
       * apply cconv_sym. eapply cconv_trans. 1: constructor.
-        cbn. ssimpl. econv.
+        cbn. rasimpl. econv.
       * {
         eapply ccmeta_conv.
         - ertype. eapply ccmeta_conv.
@@ -3275,7 +3267,7 @@ Proof.
     + econstructor.
       * etype.
       * apply cconv_sym. eapply cconv_trans. 1: constructor.
-        cbn. ssimpl. econv.
+        cbn. rasimpl. econv.
       * {
         eapply ccmeta_conv.
         - ertype. eapply ccmeta_conv.
@@ -3291,7 +3283,7 @@ Proof.
         - cbn. reflexivity.
       }
       * apply cconv_sym. eapply cconv_trans. 1: constructor.
-        cbn. ssimpl. econv.
+        cbn. rasimpl. econv.
       * {
         eapply ccmeta_conv.
         - ertype. eapply ccmeta_conv.
@@ -3301,7 +3293,7 @@ Proof.
         - cbn. reflexivity.
       }
   - eapply cconv_trans. 1: constructor.
-    cbn. ssimpl. econv.
+    cbn. rasimpl. econv.
   - ertype. eapply ccmeta_conv.
     + ertype.
     + cbn. reflexivity.
@@ -3339,12 +3331,8 @@ Proof.
               - ertype.
               - cbn. reflexivity.
             }
-            * cbn. lhs_ssimpl.
-              rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-              reflexivity.
-          + cbn. lhs_ssimpl.
-            rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-            f_equal. ssimpl. reflexivity.
+            * cbn. rasimpl. reflexivity.
+          + cbn. rasimpl. reflexivity.
         - eapply ccmeta_conv. 1: ertype.
           cbn. reflexivity.
         - eapply ccmeta_conv. 1: ertype.
@@ -3360,7 +3348,7 @@ Proof.
       * apply cconv_sym. unfold plam. eapply cconv_trans.
         1:{ constructor. 2: econv. constructor. }
         cbn. eapply cconv_trans. 1: constructor.
-        cbn. ssimpl. econv.
+        cbn. rasimpl. econv.
       * {
         eapply ccmeta_conv.
         - ertype. eapply ccmeta_conv.
@@ -3372,13 +3360,10 @@ Proof.
                   * {
                     ertype. eapply ccmeta_conv.
                     - ertype.
-                    - cbn. lhs_ssimpl. reflexivity.
+                    - cbn. rasimpl. reflexivity.
                   }
-                  * cbn. lhs_ssimpl. rewrite <- !funcomp_assoc.
-                    rewrite <- rinstInst'_cterm. reflexivity.
-                + cbn. lhs_ssimpl. rewrite <- !funcomp_assoc.
-                  rewrite <- rinstInst'_cterm. f_equal.
-                  ssimpl. reflexivity.
+                  * cbn. rasimpl. reflexivity.
+                + cbn. rasimpl. reflexivity.
               - eapply ccmeta_conv. 1: ertype.
                 reflexivity.
               - eapply ccmeta_conv. 1: ertype.
@@ -3397,7 +3382,7 @@ Proof.
       * apply cconv_sym. unfold plam. eapply cconv_trans.
         1:{ constructor. 2: econv. constructor. }
         cbn. eapply cconv_trans. 1: constructor.
-        cbn. ssimpl. econv.
+        cbn. rasimpl. econv.
       * {
         eapply ccmeta_conv.
         - ertype. eapply ccmeta_conv.
@@ -3409,13 +3394,10 @@ Proof.
                   * {
                     ertype. eapply ccmeta_conv.
                     - ertype.
-                    - cbn. lhs_ssimpl. reflexivity.
+                    - cbn. rasimpl. reflexivity.
                   }
-                  * cbn. lhs_ssimpl. rewrite <- !funcomp_assoc.
-                    rewrite <- rinstInst'_cterm. reflexivity.
-                + cbn. lhs_ssimpl. rewrite <- !funcomp_assoc.
-                  rewrite <- rinstInst'_cterm. f_equal.
-                  ssimpl. reflexivity.
+                  * cbn. rasimpl. reflexivity.
+                + cbn. rasimpl. reflexivity.
               - eapply ccmeta_conv. 1: ertype.
                 reflexivity.
               - eapply ccmeta_conv. 1: ertype.
@@ -3432,16 +3414,15 @@ Proof.
   - unfold plam. eapply cconv_trans.
     1:{ constructor. 2: econv. constructor. }
     cbn. eapply cconv_trans. 1: constructor.
-    cbn. ssimpl. econv. unfold perif. econv.
-    rewrite <- rinstInst'_cterm. econv.
+    cbn. rasimpl. econv. unfold perif. econv.
   - eapply ccmeta_conv.
     + ertype. eapply ccmeta_conv.
       * {
         ertype. eapply ccmeta_conv.
         - ertype.
-        - cbn. lhs_ssimpl. rewrite <- rinstInst'_cterm. reflexivity.
+        - cbn. rasimpl. reflexivity.
       }
-      * cbn. lhs_ssimpl. reflexivity.
+      * cbn. rasimpl. reflexivity.
     + cbn. reflexivity.
 Qed.
 
@@ -3485,8 +3466,7 @@ Proof.
                 cbn. reflexivity.
               - cbn. reflexivity.
             }
-            * cbn. f_equal. ssimpl. f_equal. f_equal.
-              rewrite rinstInst'_cterm. reflexivity.
+            * cbn. f_equal. rasimpl. reflexivity.
           + eapply ccmeta_conv. 1: ertype.
             reflexivity.
           + eapply ccmeta_conv. 1: ertype.
@@ -3503,11 +3483,11 @@ Proof.
           cbn. reflexivity.
         - apply cconv_sym. eapply cconv_trans. 1: constructor.
           cbn. econv.
-          + ssimpl. rewrite <- rinstInst'_cterm. econv.
+          + rasimpl. econv.
           + apply cconv_irr. all: escope.
             reflexivity.
           + eapply cconv_trans. 1: constructor.
-            ssimpl. rewrite <- rinstInst'_cterm. econv.
+            rasimpl. econv.
         - eapply ccmeta_conv.
           + ertype.
             * {
@@ -3526,7 +3506,7 @@ Proof.
                       cbn. reflexivity.
                     - cbn. reflexivity.
                   }
-                  * cbn. f_equal. ssimpl. rewrite rinstInst'_cterm.
+                  * cbn. f_equal. rasimpl. rewrite rinstInst'_cterm.
                     reflexivity.
                 + eapply ccmeta_conv. 1: ertype.
                   reflexivity.
@@ -3546,11 +3526,11 @@ Proof.
           cbn. reflexivity.
         - apply cconv_sym. eapply cconv_trans. 1: constructor.
           cbn. econv.
-          + ssimpl. rewrite <- rinstInst'_cterm. econv.
+          + rasimpl. econv.
           + apply cconv_irr. all: escope.
             reflexivity.
           + eapply cconv_trans. 1: constructor.
-            ssimpl. rewrite <- rinstInst'_cterm. econv.
+            rasimpl. econv.
         - eapply ccmeta_conv.
           + ertype.
             * {
@@ -3569,7 +3549,7 @@ Proof.
                       cbn. reflexivity.
                     - cbn. reflexivity.
                   }
-                  * cbn. f_equal. ssimpl. rewrite rinstInst'_cterm.
+                  * cbn. f_equal. rasimpl. rewrite rinstInst'_cterm.
                     reflexivity.
                 + eapply ccmeta_conv. 1: ertype.
                   reflexivity.
@@ -3596,7 +3576,7 @@ Proof.
                   * ertype. eapply ccmeta_conv. 1: ertype.
                     cbn. reflexivity.
                   * cbn. reflexivity.
-                + cbn. f_equal. ssimpl. rewrite rinstInst'_cterm. reflexivity.
+                + cbn. f_equal. rasimpl. rewrite rinstInst'_cterm. reflexivity.
               - eapply ccmeta_conv. 1: ertype.
                 reflexivity.
               - eapply ccmeta_conv. 1: ertype.
@@ -3741,10 +3721,10 @@ Proof.
             * ertype.
         - apply cconv_sym. eapply cconv_trans. 1: constructor.
           cbn. econv.
-          + ssimpl. rewrite rinstInst'_cterm. econv.
+          + rasimpl. rewrite rinstInst'_cterm. econv.
           + unfold perif. eapply cconv_trans. 1: constructor.
             apply cconv_sym. eapply cconv_trans. 1: constructor.
-            econv. ssimpl. rewrite rinstInst'_cterm. econv.
+            econv. rasimpl. rewrite rinstInst'_cterm. econv.
         - eapply ccmeta_conv.
           + ertype.
             * {
@@ -3763,7 +3743,7 @@ Proof.
                       cbn. reflexivity.
                     - cbn. reflexivity.
                   }
-                  * cbn. f_equal. f_equal. ssimpl.
+                  * cbn. f_equal. f_equal. rasimpl.
                     rewrite rinstInst'_cterm. reflexivity.
                 + eapply ccmeta_conv. 1: ertype.
                   reflexivity.
@@ -3778,8 +3758,7 @@ Proof.
           + cbn. reflexivity.
       }
     + eapply cconv_trans. 1: constructor.
-      cbn. lhs_ssimpl. rewrite <- !funcomp_assoc. rewrite <- !rinstInst'_cterm.
-      econv.
+      cbn. rasimpl. econv.
     + ertype.
       * eapply ccmeta_conv. 1: ertype.
         reflexivity.
@@ -3793,9 +3772,9 @@ Proof.
                 cbn. reflexivity.
               - cbn. reflexivity.
             }
-            * cbn. lhs_ssimpl. econstructor. 2: econv.
+            * cbn. rasimpl. econstructor. 2: econv.
               apply cconv_sym. eapply cconv_trans. 1: econstructor.
-              cbn. ssimpl. rewrite rinstInst'_cterm. econv.
+              cbn. rasimpl. rewrite rinstInst'_cterm. econv.
             * {
               ertype. eapply ccmeta_conv.
               - ertype.
@@ -3817,7 +3796,7 @@ Proof.
           + econstructor.
             * ertype.
             * apply cconv_sym. eapply cconv_trans. 1: constructor.
-              cbn. ssimpl. rewrite rinstInst'_cterm. econv.
+              cbn. rasimpl. rewrite rinstInst'_cterm. econv.
             * {
               eapply ccmeta_conv.
               - ertype. eapply ccmeta_conv.
@@ -3829,7 +3808,7 @@ Proof.
           + econstructor.
             * ertype.
             * apply cconv_sym. eapply cconv_trans. 1: constructor.
-              cbn. ssimpl. rewrite rinstInst'_cterm. econv.
+              cbn. rasimpl. rewrite rinstInst'_cterm. econv.
             * {
               eapply ccmeta_conv.
               - ertype. eapply ccmeta_conv.
@@ -3846,7 +3825,7 @@ Proof.
               - cbn. reflexivity.
             }
             * apply cconv_sym. eapply cconv_trans. 1: constructor.
-              cbn. ssimpl. rewrite rinstInst'_cterm. econv.
+              cbn. rasimpl. rewrite rinstInst'_cterm. econv.
             * {
               eapply ccmeta_conv.
               - ertype. eapply ccmeta_conv.
@@ -3857,8 +3836,7 @@ Proof.
             }
         - cbn. reflexivity.
       }
-  - cbn. ssimpl. unfold perif.
-    rewrite rinstInst'_cterm. reflexivity.
+  - cbn. rasimpl. unfold perif. reflexivity.
 Qed.
 
 Hint Opaque pmifK : cc_type.
@@ -3983,18 +3961,18 @@ Proof.
                 cbn. econv. apply ccmeta_refl.
                 unfold close. unfold Be.
                 change (epm_lift ?t) with (vreg ⋅ t).
-                change (λ n, S (S n)) with (S >> S). ssimpl.
+                change (λ n, S (S n)) with (S >> S). rasimpl.
                 eapply ext_cterm_scoped. 1: apply erase_scoping.
                 intros [] hx. 1: discriminate.
-                cbn. ssimpl. reflexivity.
+                cbn. rasimpl. reflexivity.
               - cbn. eapply cconv_trans. 1: constructor.
                 cbn. econv. apply ccmeta_refl.
                 unfold close. unfold Be.
                 change (epm_lift ?t) with (vreg ⋅ t).
-                change (λ n, S (S n)) with (S >> S). ssimpl.
+                change (λ n, S (S n)) with (S >> S). rasimpl.
                 eapply ext_cterm_scoped. 1: apply erase_scoping.
                 intros [] hx. 1: discriminate.
-                cbn. ssimpl. reflexivity.
+                cbn. rasimpl. reflexivity.
             }
             * {
               cbn. ertype.
@@ -4039,7 +4017,7 @@ Proof.
               all: eapply crtyping_shift_eq.
               1,3: eapply crtyping_shift ; apply crtyping_S.
               all: cbn. all: f_equal.
-              all: ssimpl. all: reflexivity.
+              all: rasimpl. all: reflexivity.
             * {
               cbn. instantiate (1 := if isKind m then _ else _).
               destruct (isKind m) eqn:ek.
@@ -4055,10 +4033,10 @@ Proof.
                   destruct_if emx.
                   * eapply crtyping_shift_eq with (A := capp (S ⋅ Ap) (cvar 0)).
                     1:{ eapply crtyping_shift with (A := cEl Ae). apply crtyping_S. }
-                    cbn. f_equal. ssimpl. reflexivity.
+                    cbn. f_equal. rasimpl. reflexivity.
                   * eapply crtyping_shift_eq with (A := capp (S ⋅ Ap) (cvar 0)).
                     1:{ eapply crtyping_shift with (A := cEl Ae). apply crtyping_S. }
-                    cbn. f_equal. ssimpl. reflexivity.
+                    cbn. f_equal. rasimpl. reflexivity.
                 + cbn. reflexivity.
               - instantiate (2 := if isKind m then _ else _).
                 instantiate (1 := if isKind m then _ else _).
@@ -4086,7 +4064,7 @@ Proof.
               - ertype. eapply ccmeta_conv. 1: ertype. 2: reflexivity.
                 eapply crtyping_shift_eq with (A := capp (S ⋅ Ap) (cvar 0)).
                 1:{ eapply crtyping_shift with (A := cEl Ae). apply crtyping_S. }
-                cbn. f_equal. ssimpl. reflexivity.
+                cbn. f_equal. rasimpl. reflexivity.
             }
             * {
               eapply ccmeta_conv.
@@ -4098,12 +4076,12 @@ Proof.
                   2: destruct (isGhost m && isGhost mx) eqn:eg.
                   * cbn. eapply cconv_trans. 1: constructor.
                     econstructor.
-                    1:{ apply ccmeta_refl. ssimpl. reflexivity. }
+                    1:{ apply ccmeta_refl. rasimpl. reflexivity. }
                     econv.
                   * cbn. eapply cconv_trans. 1: constructor.
                     econstructor.
-                    1:{ apply ccmeta_refl. ssimpl. reflexivity. }
-                    apply ccmeta_refl. ssimpl.
+                    1:{ apply ccmeta_refl. rasimpl. reflexivity. }
+                    apply ccmeta_refl. rasimpl.
                     rewrite rinstInst'_cterm. f_equal.
                     eapply ext_cterm_scoped. 1: apply erase_scoping.
                     intros [] hx.
@@ -4127,7 +4105,7 @@ Proof.
                           ertype. all: shelve.
                         * f_equal. f_equal. f_equal.
                           change (λ n, S (S (S n))) with (S >> S >> S).
-                          ssimpl. reflexivity.
+                          rasimpl. reflexivity.
                       + cbn.
                         destruct (relm mx) eqn:emx.
                         * eapply crtyping_shift_eq.
@@ -4142,8 +4120,8 @@ Proof.
                 ssimpl. f_equal. rewrite rinstInst'_cterm.
                 ssimpl. eapply ext_cterm_scoped. 1: apply erase_scoping.
                 intros [] hx. 1: reflexivity.
-                ssimpl. change (vreg (S ?x)) with (S (S (vreg x))).
-                cbn. ssimpl. reflexivity.
+                rasimpl. change (vreg (S ?x)) with (S (S (vreg x))).
+                cbn. rasimpl. reflexivity.
             }
         - instantiate (2 := if isKind m then _ else _).
           instantiate (1 := if isKind m then _ else _).
@@ -4318,7 +4296,7 @@ Proof.
           exact ey.
         }
         2:{ intros y ey. rewrite <- nth_error_skipn in ey. assumption. }
-        ssimpl. eapply extRen_cterm. intro n.
+        rasimpl. eapply extRen_cterm. intro n.
         rewrite pren_comp_S. rewrite pren_plus.
         unfold vreg. lia.
     + eapply ccmeta_conv.
@@ -4330,15 +4308,15 @@ Proof.
         }
         2:{ intros y ey. rewrite <- nth_error_skipn in ey. assumption. }
         destruct_ifs.
-        -- ssimpl. f_equal.
-          ++ eapply extRen_cterm. intro. ssimpl.
+        -- rasimpl. f_equal.
+          ++ eapply extRen_cterm. intro. rasimpl.
             rewrite pren_comp_S. rewrite pren_plus.
-            unfold vpar. lia.
+            unfold vpar. unfold shift, funcomp. lia.
           ++ rewrite epm_lift_eq. cbn. f_equal. unfold vpar, vreg. lia.
-        -- ssimpl. f_equal.
-          ++ eapply extRen_cterm. intro. ssimpl.
+        -- rasimpl. f_equal.
+          ++ eapply extRen_cterm. intro. rasimpl.
             rewrite pren_comp_S. rewrite pren_plus.
-            unfold vpar. lia.
+            unfold vpar. unfold shift, funcomp. lia.
           ++ rewrite epm_lift_eq. cbn. f_equal. unfold vpar, vreg. lia.
         -- destruct m. all: discriminate.
   - cbn. destruct_ifs. all: mode_eqs. all: try discriminate.
@@ -4425,8 +4403,8 @@ Proof.
             change (epm_lift ?t) with (vreg ⋅ t). ssimpl.
             eapply ext_cterm_scoped. 1: apply erase_scoping.
             intros [] hx. 1: discriminate.
-            ssimpl. change (vreg (S ?x)) with (S (S (vreg x))).
-            ssimpl. reflexivity.
+            rasimpl. change (vreg (S ?x)) with (S (S (vreg x))).
+            rasimpl. reflexivity.
         - destruct_if eg.
           + mode_eqs. cbn. eapply cconv_trans. 1: constructor.
             cbn. ssimpl. econv.
@@ -4436,8 +4414,8 @@ Proof.
               change (rpm_lift ?t) with (vreg ⋅ t). ssimpl.
               eapply ext_cterm_scoped. 1: apply revive_scoping.
               intros [] hx. 1: discriminate.
-              ssimpl. change (vreg (S ?x)) with (S (S (vreg x))).
-              ssimpl. reflexivity.
+              rasimpl. change (vreg (S ?x)) with (S (S (vreg x))).
+              rasimpl. reflexivity.
           + destruct_if ep. 2:{ destruct m. all: discriminate. }
             apply cconv_refl.
       }
@@ -4628,18 +4606,18 @@ Proof.
           + destruct (isGhost mx) eqn:egx.
             * mode_eqs. cbn. apply ccmeta_refl. unfold close.
               change (epm_lift ?t) with (vreg ⋅ t).
-              ssimpl. rewrite rinstInst'_cterm.
+              rasimpl. rewrite rinstInst'_cterm.
               eapply ext_cterm_scoped. 1: apply erase_scoping.
               intros [] hx. 1: discriminate.
-              cbn. ssimpl. reflexivity.
+              cbn. rasimpl. reflexivity.
             * subst rmx. destruct (relm mx) eqn: emx.
               2:{ destruct mx. all: discriminate. }
               cbn. change (epm_lift ?t) with (vreg ⋅ t).
               cbn. eapply cconv_trans. 1: constructor.
-              apply ccmeta_refl. ssimpl. rewrite rinstInst'_cterm.
+              apply ccmeta_refl. rasimpl. rewrite rinstInst'_cterm.
               eapply ext_cterm_scoped. 1: apply erase_scoping.
               intros [] hx. 1: reflexivity.
-              ssimpl. reflexivity.
+              rasimpl. reflexivity.
         - destruct (isGhost m) eqn: eg.
           + mode_eqs. simpl. unfold pmPiNP. rewrite exp.
             apply cconv_sym. eapply cconv_trans. 1: constructor.
@@ -4654,10 +4632,10 @@ Proof.
               eapply ext_cterm. intros [| []]. all: reflexivity.
             * change (rpm_lift ?t) with (vreg ⋅ t). cbn.
               eapply cconv_trans. 1: constructor.
-              apply ccmeta_refl. ssimpl. rewrite rinstInst'_cterm.
+              apply ccmeta_refl. rasimpl. rewrite rinstInst'_cterm.
               eapply ext_cterm_scoped. 1: apply revive_scoping.
               intros [] hx. 1: reflexivity.
-              ssimpl. reflexivity.
+              rasimpl. reflexivity.
           + destruct m. all: try discriminate.
             cbn. unfold pmPiP. rewrite exp.
             destruct_if e.
@@ -4760,20 +4738,20 @@ Proof.
                     with (ctyval mk (epm_lift u) (epm_lift v)).
                     unfold pType.
                     eapply cconv_trans. 1: constructor.
-                    cbn. ssimpl. change (epm_lift ?t) with (vreg ⋅ t).
-                    cbn. ssimpl. econv.
+                    cbn. rasimpl. change (epm_lift ?t) with (vreg ⋅ t).
+                    cbn. rasimpl. econv.
                     - apply ccmeta_refl. rewrite rinstInst'_cterm.
                       eapply ext_cterm_scoped. 1: apply erase_scoping.
                       intros [] hx.
                       + cbn in hx. rewrite erx in hx.
                         discriminate.
-                      + ssimpl. reflexivity.
+                      + rasimpl. reflexivity.
                     - apply ccmeta_refl. rewrite rinstInst'_cterm.
                       eapply ext_cterm_scoped. 1: apply erase_scoping.
                       intros [] hx.
                       + cbn in hx. rewrite erx in hx.
                         discriminate.
-                      + ssimpl. reflexivity.
+                      + rasimpl. reflexivity.
                   }
                   * destruct mx. all: discriminate.
                 + ertype.
@@ -4959,7 +4937,7 @@ Proof.
           simpl.
           instantiate (1 := if isProp mx then _ else _).
           destruct (isProp mx) eqn:epx.
-          * mode_eqs. cbn. lhs_ssimpl. econv.
+          * mode_eqs. cbn. rasimpl. econv.
           * unfold pPi. cbn. lhs_ssimpl.
             rewrite andb_false_r. cbn.
             rewrite <- rinstInst'_cterm. econv.
@@ -4983,13 +4961,12 @@ Proof.
                 * {
                   eapply ctyping_subst. 2: eassumption.
                   constructor.
-                  - ssimpl. constructor.
-                    + ssimpl. apply crtyping_typing.
+                  - rasimpl. constructor.
+                    + rasimpl. apply crtyping_typing.
                       apply crtyping_S.
                     + cbn. split.
                       * constructor. reflexivity.
-                      * ssimpl. rewrite <- rinstInst'_cterm.
-                        ertype.
+                      * rasimpl. ertype.
                   - cbn. constructor.
                 }
                 * cbn. change (epm_lift ?t) with (vreg ⋅ t). cbn.
@@ -5013,13 +4990,12 @@ Proof.
                 * {
                   eapply ctyping_subst. 2: eassumption.
                   constructor.
-                  - ssimpl. constructor.
-                    + ssimpl. apply crtyping_typing.
+                  - rasimpl. constructor.
+                    + rasimpl. apply crtyping_typing.
                       apply crtyping_S.
                     + cbn. split.
                       * constructor. reflexivity.
-                      * ssimpl. rewrite <- rinstInst'_cterm.
-                        ertype.
+                      * rasimpl. ertype.
                   - cbn. constructor.
                 }
                 * cbn. econstructor. 2: econv.
@@ -5060,30 +5036,30 @@ Proof.
                 * {
                   eapply ctyping_subst. 2: eassumption.
                   destruct (isKind mx) eqn:ek.
-                  - constructor. 1: ssimpl. 1: constructor. 1: ssimpl.
+                  - constructor. 1: rasimpl. 1: constructor. 1: rasimpl.
                     + rewrite <- !funcomp_assoc.
                       apply crtyping_typing. ertype.
                     + cbn. split.
                       * ertype.
                       * eapply ccmeta_conv. 1: ertype.
                         cbn. change (λ n, S (S n)) with (S >> S).
-                        ssimpl. rewrite rinstInst'_cterm. reflexivity.
+                        rasimpl. rewrite rinstInst'_cterm. reflexivity.
                     + cbn. split.
                       * ertype.
                       * eapply ccmeta_conv. 1: ertype.
-                        cbn. ssimpl. rewrite rinstInst'_cterm. reflexivity.
-                  - constructor. 1: ssimpl. 1: constructor. 1: ssimpl.
+                        cbn. rasimpl. rewrite rinstInst'_cterm. reflexivity.
+                  - constructor. 1: rasimpl. 1: constructor. 1: rasimpl.
                     + rewrite <- !funcomp_assoc.
                       apply crtyping_typing. ertype.
                     + cbn. split.
                       * ertype.
                       * eapply ccmeta_conv. 1: ertype.
                         cbn. change (λ n, S (S n)) with (S >> S).
-                        ssimpl. rewrite rinstInst'_cterm. reflexivity.
+                        rasimpl. rewrite rinstInst'_cterm. reflexivity.
                     + cbn. split.
                       * ertype.
                       * eapply ccmeta_conv. 1: ertype.
-                        cbn. ssimpl. rewrite rinstInst'_cterm. reflexivity.
+                        cbn. rasimpl. rewrite rinstInst'_cterm. reflexivity.
                 }
                 * instantiate (1 := if isKind m then _ else _).
                   destruct (isKind m) eqn:ek. all: cbn. all: reflexivity.
@@ -5100,7 +5076,7 @@ Proof.
                     intros [| []] hx. 1: discriminate. all: reflexivity.
                   - ertype. eapply ccmeta_conv.
                     + eapply ctyping_subst. 2: ertype.
-                      cbn. constructor. 1: ssimpl. 1: constructor. 1: ssimpl.
+                      cbn. constructor. 1: rasimpl. 1: constructor. 1: rasimpl.
                       * rewrite <- !funcomp_assoc.
                         apply crtyping_typing. ertype.
                       * {
@@ -5108,13 +5084,13 @@ Proof.
                         - ertype.
                         - eapply ccmeta_conv. 1: ertype.
                           cbn. change (λ n, S (S n)) with (S >> S).
-                          ssimpl. rewrite rinstInst'_cterm. reflexivity.
+                          rasimpl. rewrite rinstInst'_cterm. reflexivity.
                       }
                       * {
                         cbn. split.
                         - ertype.
                         - eapply ccmeta_conv. 1: ertype.
-                          cbn. ssimpl. rewrite rinstInst'_cterm. reflexivity.
+                          cbn. rasimpl. rewrite rinstInst'_cterm. reflexivity.
                       }
                     + cbn. reflexivity.
                 }
@@ -5145,7 +5121,7 @@ Proof.
                         - ertype.
                       }
                   - cbn. f_equal. change (epm_lift ?t) with (vreg ⋅ t).
-                    ssimpl. eapply ext_cterm_scoped. 1: apply erase_scoping.
+                    rasimpl. eapply ext_cterm_scoped. 1: apply erase_scoping.
                     intros [| []] hx. all: reflexivity.
                 }
             - destruct (isKind m) eqn:ek. all: cbn. all: reflexivity.
@@ -5157,12 +5133,11 @@ Proof.
             mode_eqs. ertype. eapply ccmeta_conv.
             - ertype. econstructor.
               + eapply ctyping_subst. 2: ertype.
-                constructor. 1: ssimpl. 1: constructor.
+                constructor.
                 * ssimpl. apply crtyping_typing. ertype.
                 * cbn. split. 1: ertype.
                   eapply ccmeta_conv. 1: ertype.
-                  cbn. ssimpl. rewrite rinstInst'_cterm. reflexivity.
-                * cbn. constructor.
+                  cbn. rasimpl. rewrite rinstInst'_cterm. reflexivity.
               + cbn. apply cconv_sym. change (epm_lift ?t) with (vreg ⋅ t).
                 cbn. econstructor. 2: econv.
                 eapply cconv_trans. 1: constructor.
@@ -5240,7 +5215,7 @@ Proof.
                   eapply ccmeta_conv.
                   - eapply ctyping_subst. 2: ertype.
                     destruct (isKind mx) eqn:ekx.
-                    + constructor. 1: ssimpl. 1: constructor. 1: ssimpl.
+                    + constructor. 1: rasimpl. 1: constructor. 1: rasimpl.
                       * rewrite <- !funcomp_assoc.
                         apply crtyping_typing. ertype.
                       * {
@@ -5248,15 +5223,15 @@ Proof.
                         - ertype.
                         - eapply ccmeta_conv. 1: ertype.
                           cbn. change (λ n, S (S n)) with (S >> S).
-                          ssimpl. rewrite rinstInst'_cterm. reflexivity.
+                          rasimpl. rewrite rinstInst'_cterm. reflexivity.
                       }
                       * {
                         cbn. split.
                         - ertype.
                         - eapply ccmeta_conv. 1: ertype.
-                          cbn. ssimpl. rewrite rinstInst'_cterm. reflexivity.
+                          cbn. rasimpl. rewrite rinstInst'_cterm. reflexivity.
                       }
-                    + constructor. 1: ssimpl. 1: constructor. 1: ssimpl.
+                    + constructor. 1: rasimpl. 1: constructor. 1: rasimpl.
                       * rewrite <- !funcomp_assoc.
                         apply crtyping_typing. ertype.
                       * {
@@ -5264,21 +5239,21 @@ Proof.
                         - ertype.
                         - eapply ccmeta_conv. 1: ertype.
                           cbn. change (λ n, S (S n)) with (S >> S).
-                          ssimpl. rewrite rinstInst'_cterm. reflexivity.
+                          rasimpl. rewrite rinstInst'_cterm. reflexivity.
                       }
                       * {
                         cbn. split.
                         - ertype.
                         - eapply ccmeta_conv. 1: ertype.
-                          cbn. ssimpl. rewrite rinstInst'_cterm. reflexivity.
+                          cbn. rasimpl. rewrite rinstInst'_cterm. reflexivity.
                       }
                   - cbn. f_equal.
                     change (epm_lift ?t) with (vreg ⋅ t).
                     destruct (relm mx) eqn:erx.
-                    + ssimpl. f_equal.
+                    + rasimpl. f_equal.
                       eapply ext_cterm_scoped. 1: apply erase_scoping.
                       intros [| []] hx. all: reflexivity.
-                    + ssimpl. f_equal.
+                    + rasimpl. f_equal.
                       eapply ext_cterm_scoped. 1: apply erase_scoping.
                       intros [| []] hx. 2,3: reflexivity.
                       cbn in hx. rewrite erx in hx. discriminate.
@@ -5321,32 +5296,32 @@ Proof.
             * {
               destruct (isKind mx) eqn:ekx.
               - cbn. lhs_ssimpl. reflexivity.
-              - cbn. ssimpl. reflexivity.
+              - cbn. rasimpl. reflexivity.
             }
       }
       * {
         destruct rm eqn:erm.
-        - ssimpl. f_equal.
+        - rasimpl. f_equal.
           erewrite param_subst.
           2:{ apply sscoping_one. escope. }
           2: apply sscoping_comp_one.
           eapply ext_cterm_scoped. 1:{ apply param_scoping. eassumption. }
           intros [| []] hx. all: cbn.
           + rewrite erx. reflexivity.
-          + rewrite erx. ssimpl. reflexivity.
+          + rewrite erx. rasimpl. reflexivity.
           + apply psubst_SS_id. assumption.
         - destruct (isGhost m) eqn:egm.
-          + mode_eqs. ssimpl. f_equal.
+          + mode_eqs. rasimpl. f_equal.
             erewrite param_subst.
             2:{ apply sscoping_one. escope. }
             2: apply sscoping_comp_one.
             eapply ext_cterm_scoped. 1:{ apply param_scoping. eassumption. }
             intros [| []] hx. all: cbn.
             * rewrite erx. reflexivity.
-            * rewrite erx. ssimpl. reflexivity.
+            * rewrite erx. rasimpl. reflexivity.
             * apply psubst_SS_id. assumption.
           + destruct m. all: try discriminate.
-            ssimpl.
+            rasimpl.
             erewrite param_subst.
             2:{ apply sscoping_one. escope. }
             2: apply sscoping_comp_one.
@@ -5375,21 +5350,21 @@ Proof.
             }
         - instantiate (1 := if rm then _ else if isGhost m then _ else _).
           destruct rm eqn:er. 2: destruct (isGhost m) eqn:eg.
-          + cbn. f_equal. ssimpl. reflexivity.
-          + cbn. f_equal. ssimpl. reflexivity.
+          + cbn. f_equal. rasimpl. reflexivity.
+          + cbn. f_equal. rasimpl. reflexivity.
           + destruct m. all: try discriminate.
-            cbn. f_equal. ssimpl. reflexivity.
+            cbn. f_equal. rasimpl. reflexivity.
       }
       * {
         destruct rm eqn:er. 2: destruct (isGhost m) eqn:eg.
-        - cbn. ssimpl. f_equal.
+        - cbn. rasimpl. f_equal.
           erewrite param_subst.
           2:{ apply sscoping_one. escope. }
           2: apply sscoping_comp_one.
           eapply ext_cterm_scoped. 1:{ apply param_scoping. eassumption. }
           intros [| []] hx. all: cbn.
           + reflexivity.
-          + reflexivity.
+          + ssimpl. reflexivity.
           + apply psubst_SS_id. assumption.
         - mode_eqs. cbn. ssimpl. f_equal.
           erewrite param_subst.
@@ -5399,7 +5374,7 @@ Proof.
           intros [| []] hx. all: cbn. 1,2: reflexivity.
           apply psubst_SS_id. assumption.
         - destruct m. all: try discriminate.
-          ssimpl.
+          rasimpl.
           erewrite param_subst.
           2:{ apply sscoping_one. escope. }
           2: apply sscoping_comp_one.
@@ -5422,7 +5397,7 @@ Proof.
       }
       * {
         destruct rm eqn:er. 2: destruct (isGhost m) eqn:eg.
-        - cbn. ssimpl. f_equal.
+        - cbn. rasimpl. f_equal.
           erewrite param_subst.
           2:{ apply sscoping_one. escope. }
           2: apply sscoping_comp_one.
@@ -5517,9 +5492,7 @@ Proof.
             * hide_rhs rhs. erewrite param_ren.
               2: apply rscoping_S.
               2: apply rscoping_comp_S.
-              ssimpl. rewrite pren_S_pw. ssimpl.
-              rewrite <- funcomp_assoc.
-              rewrite <- rinstInst'_cterm.
+              rasimpl. rewrite pren_S_pw. rasimpl.
               unfold rhs. reflexivity.
             * hide_rhs rhs.
               rewrite rpm_lift_eq. cbn.
@@ -5550,10 +5523,10 @@ Proof.
                   * eapply ctyping_ren. 1: etype.
                     etype.
                   * cbn. reflexivity.
-                + tm_ssimpl.
+                + rasimpl.
                   erewrite erase_ren.
                   2: apply rscoping_S. 2: apply rscoping_comp_S.
-                  tm_ssimpl.
+                  rasimpl.
                   econstructor.
                   * eapply ctyping_ren.
                     1:{
@@ -5572,14 +5545,12 @@ Proof.
                   * eapply ctyping_ren. 1: etype.
                     etype.
                   * cbn. reflexivity.
-                + cbn. f_equal. ssimpl.
-                  rewrite <- funcomp_assoc.
-                  rewrite <- rinstInst'_cterm. reflexivity.
-              - cbn. f_equal. ssimpl.
+                + cbn. f_equal. rasimpl. reflexivity.
+              - cbn. f_equal. rasimpl.
                 rewrite param_erase_ty_tm. cbn.
                 erewrite erase_ren.
                 2: apply rscoping_S. 2: apply rscoping_comp_S.
-                ssimpl. rewrite epm_lift_eq. ssimpl. reflexivity.
+                rasimpl. rewrite epm_lift_eq. rasimpl. reflexivity.
             }
           + cbn. reflexivity.
       }
@@ -5590,9 +5561,9 @@ Proof.
         - etype. eapply ccmeta_conv.
           + etype.
           + reflexivity.
-        - cbn. f_equal. ssimpl. reflexivity.
+        - cbn. f_equal. rasimpl. reflexivity.
       }
-      * cbn. ssimpl. reflexivity.
+      * cbn. rasimpl. reflexivity.
     + cbn in *.
       (* Preprocessing hypotheses *)
       eapply ctype_conv in IHh2.
@@ -5632,9 +5603,9 @@ Proof.
         - etype. eapply ccmeta_conv.
           + etype.
           + reflexivity.
-        - cbn. f_equal. ssimpl. reflexivity.
+        - cbn. f_equal. rasimpl. reflexivity.
       }
-      * cbn. ssimpl. reflexivity.
+      * cbn. rasimpl. reflexivity.
   - unfold ptype. cbn.
     remd. cbn. change (epm_lift ctt) with ctt.
     unfold ptype in IHh1. remd in IHh1. cbn in IHh1. remd in IHh1. cbn in IHh1.
@@ -5645,7 +5616,7 @@ Proof.
         etype. econstructor.
         - etype.
         - eapply cconv_trans. 1: constructor.
-          cbn. econv. ssimpl. econv.
+          cbn. econv. rasimpl. econv.
         - etype.
           + cbn. etype.
           + eapply ccmeta_conv.
@@ -5658,7 +5629,7 @@ Proof.
                   - eapply cstyping_one.
                     + escope.
                     + etype.
-                  - f_equal. f_equal. f_equal. ssimpl. reflexivity.
+                  - f_equal. f_equal. f_equal. rasimpl. reflexivity.
                 }
                 eapply ctyping_ren. 1: eapply crtyping_S.
                 eapply ctyping_ren. 1: eapply crtyping_S.
@@ -5666,7 +5637,7 @@ Proof.
               - cbn. unfold ptype. remd. cbn.
                 eapply cconv_trans. 1: constructor.
                 cbn. econv. rewrite param_erase_ty_tm.
-                ssimpl. rewrite rinstInst'_cterm. econv.
+                rasimpl. rewrite rinstInst'_cterm. econv.
               - etype. eapply ccmeta_conv.
                 + eapply ctyping_ren. 1: eapply crtyping_S.
                   cbn. etype.
@@ -5683,7 +5654,7 @@ Proof.
                   etype.
                 + cbn. change (epm_lift (cEl ?A)) with (vreg ⋅ (cEl A)).
                   cbn. eapply cconv_trans. 1: constructor.
-                  econv. ssimpl. econv.
+                  econv. rasimpl. econv.
                 + etype. eapply ccmeta_conv.
                   * eapply ctyping_ren. 1: etype.
                     cbn. etype.
@@ -5693,7 +5664,7 @@ Proof.
             }
             * cbn. reflexivity.
       }
-      * cbn. f_equal. ssimpl. reflexivity.
+      * cbn. f_equal. rasimpl. reflexivity.
     + cbn. eapply cconv_trans. 1: constructor.
       cbn. apply cconv_sym. eapply cconv_trans. 1: constructor.
       cbn. econv.
@@ -5841,8 +5812,8 @@ Proof.
         - cbn. reflexivity.
       }
       (* End *)
-      cbn. unfold pcastP. cbn. ssimpl.
-      change (λ m, S (S (S m))) with (S >> S >> S). ssimpl.
+      cbn. unfold pcastP. cbn. rasimpl.
+      change (λ m, S (S (S m))) with (S >> S >> S). rasimpl.
       econstructor.
       * {
         etype.
@@ -5854,16 +5825,16 @@ Proof.
                 + eapply ccmeta_conv.
                   * eapply ctyping_ren. 1: apply crtyping_S.
                     etype.
-                  * cbn. lhs_ssimpl. reflexivity.
+                  * cbn. rasimpl. reflexivity.
                 + eapply ctyping_ren. 1: apply crtyping_S.
                   etype.
-              - cbn. lhs_ssimpl. reflexivity.
+              - cbn. rasimpl. reflexivity.
             }
             * {
               eapply ccmeta_conv.
               - eapply ctyping_ren. 1: apply crtyping_S.
                 etype.
-              - cbn. ssimpl. rewrite <- rinstInst'_cterm. reflexivity.
+              - cbn. rasimpl. reflexivity.
             }
           + cbn. reflexivity.
         - econstructor.
@@ -5873,7 +5844,7 @@ Proof.
               - etype.
                 + eapply ccmeta_conv.
                   * etype.
-                  * cbn. lhs_ssimpl. reflexivity.
+                  * cbn. rasimpl. reflexivity.
                 + eapply ccmeta_conv.
                   * eapply ctyping_ren. 1: apply crtyping_S.
                     etype.
@@ -5889,12 +5860,12 @@ Proof.
                       etype.
                     - eapply ccmeta_conv.
                       + etype.
-                      + cbn. ssimpl. reflexivity.
+                      + cbn. rasimpl. reflexivity.
                     - eapply ccmeta_conv.
                       + etype. eapply ccmeta_conv.
                         * eapply ctyping_ren. 1: etype.
                           etype.
-                        * cbn. f_equal. ssimpl. reflexivity.
+                        * cbn. f_equal. rasimpl. reflexivity.
                       + cbn. reflexivity.
                     - eapply ccmeta_conv.
                       + etype. eapply ccmeta_conv.
@@ -5902,14 +5873,12 @@ Proof.
                           etype. eapply ccmeta_conv.
                           - eapply ctyping_ren. 1: etype.
                             etype.
-                          - cbn. f_equal. ssimpl. reflexivity.
+                          - cbn. f_equal. rasimpl. reflexivity.
                         }
-                        * cbn. f_equal. ssimpl.
-                          rewrite <- !funcomp_assoc.
-                          rewrite <- rinstInst'_cterm. reflexivity.
+                        * cbn. f_equal. rasimpl. reflexivity.
                       + cbn. reflexivity.
                   }
-                  * cbn. f_equal. ssimpl. reflexivity.
+                  * cbn. f_equal. rasimpl. reflexivity.
                 + econstructor.
                   * {
                     etype.
@@ -5933,7 +5902,7 @@ Proof.
                       constructor.
                     }
                     cbn. eapply cconv_trans. 1: constructor.
-                    cbn. ssimpl.
+                    cbn. rasimpl.
                     rewrite !rinstInst'_cterm.
                     econv.
                     apply cconv_irr.
@@ -5961,12 +5930,12 @@ Proof.
                           - eapply ctyping_ren. all: etype.
                           - eapply ccmeta_conv.
                             + etype.
-                            + cbn. ssimpl. reflexivity.
+                            + cbn. rasimpl. reflexivity.
                           - eapply ccmeta_conv.
                             + etype.
                               eapply ccmeta_conv.
                               * eapply ctyping_ren. all: etype.
-                              * cbn. f_equal. ssimpl. reflexivity.
+                              * cbn. f_equal. rasimpl. reflexivity.
                             + cbn. reflexivity.
                           - eapply ccmeta_conv.
                             + etype.
@@ -5974,14 +5943,13 @@ Proof.
                               * etype.
                                 eapply ccmeta_conv.
                                 -- eapply ctyping_ren. all: etype.
-                                -- cbn. f_equal. ssimpl. reflexivity.
-                              * cbn. f_equal. ssimpl.
-                                rewrite rinstInst'_cterm. ssimpl. reflexivity.
+                                -- cbn. f_equal. rasimpl. reflexivity.
+                              * cbn. f_equal. rasimpl.
+                                rewrite rinstInst'_cterm. rasimpl. reflexivity.
                             + cbn. reflexivity.
                           - eapply ctyping_ren. all: etype.
                         }
-                        * cbn. f_equal. ssimpl. rewrite <- !rinstInst'_cterm.
-                          reflexivity.
+                        * cbn. f_equal. rasimpl. reflexivity.
                       + eapply ccmeta_conv.
                         * eapply ctyping_ren. all: etype.
                         * cbn. reflexivity.
@@ -5994,9 +5962,7 @@ Proof.
                   constructor.
                 }
                 cbn. eapply cconv_trans. 1: constructor.
-                lhs_ssimpl. rewrite <- !funcomp_assoc.
-                rewrite <- !rinstInst'_cterm.
-                econv.
+                rasimpl. econv.
               - etype.
                 + eapply ccmeta_conv.
                   * {
@@ -6013,9 +5979,9 @@ Proof.
                     - etype.
                       + eapply ccmeta_conv.
                         * eapply ctyping_ren. all: etype.
-                        * cbn. lhs_ssimpl. reflexivity.
+                        * cbn. rasimpl. reflexivity.
                       + eapply ctyping_ren. all: etype.
-                    - cbn. f_equal. ssimpl. rewrite !rinstInst'_cterm.
+                    - cbn. f_equal. rasimpl. rewrite !rinstInst'_cterm.
                       reflexivity.
                   }
                   * cbn. reflexivity.
@@ -6025,9 +5991,9 @@ Proof.
               - eapply ctyping_ren. all: etype.
               - cbn. reflexivity.
             }
-          + cbn. ssimpl. apply cconv_sym. eapply cconv_trans. 1: constructor.
-            cbn. ssimpl. rewrite <- !rinstInst'_cterm. econv.
-          + tm_ssimpl. eapply ccmeta_conv.
+          + cbn. rasimpl. apply cconv_sym. eapply cconv_trans. 1: constructor.
+            cbn. rasimpl. econv.
+          + rasimpl. eapply ccmeta_conv.
             * {
               etype.
               - eapply ccmeta_conv.
@@ -6040,12 +6006,10 @@ Proof.
                   * {
                     eapply ccmeta_conv.
                     - eapply ctyping_ren. all: etype.
-                    - cbn. lhs_ssimpl. reflexivity.
+                    - cbn. rasimpl. reflexivity.
                   }
                   * eapply ctyping_ren. all: etype.
-                + cbn. lhs_ssimpl. rewrite <- !funcomp_assoc.
-                  rewrite <- !rinstInst'_cterm.
-                  reflexivity.
+                + cbn. rasimpl. reflexivity.
               - eapply ccmeta_conv.
                 + eapply ctyping_ren. all: etype.
                 + cbn. reflexivity.
@@ -6061,13 +6025,13 @@ Proof.
             * cbn. reflexivity.
       }
       * eapply cconv_trans. 1: constructor.
-        cbn. ssimpl. econv.
+        cbn. rasimpl. econv.
       * {
         eapply ccmeta_conv.
         - etype.
           eapply ccmeta_conv.
           + etype.
-          + cbn. lhs_ssimpl. reflexivity.
+          + cbn. rasimpl. reflexivity.
         - cbn. reflexivity.
       }
   - cbn. change (epm_lift ?t) with t.
@@ -6089,7 +6053,7 @@ Proof.
     eapply ctype_conv in IHh2.
     2:{
       unfold pmPiNP. eapply cconv_trans. 1: constructor.
-      cbn. lhs_ssimpl. econstructor.
+      cbn. rasimpl. econstructor.
       - rewrite epm_lift_eq. cbn. constructor.
       - econstructor. 1: econv.
         instantiate (1 := if isProp m then _ else cPi _ _ (if isKind m then _ else _)).
@@ -6167,9 +6131,9 @@ Proof.
       }
       eapply ccmeta_conv.
       * ertype.
-        unfold pPi. cbn. ssimpl. assumption.
+        unfold pPi. cbn. rasimpl. assumption.
       * f_equal. unfold perif. change (epm_lift ?t) with (vreg ⋅ t).
-        cbn. f_equal. f_equal. f_equal. f_equal. ssimpl. reflexivity.
+        cbn. f_equal. f_equal. f_equal. f_equal. rasimpl. reflexivity.
     + cbn in *.
       eapply param_erase_typing in h3 as hte. 2: ertype.
       cbn in hte. remd in hte. cbn in hte.
@@ -6185,9 +6149,9 @@ Proof.
       }
       eapply ccmeta_conv.
       * ertype.
-        unfold pPi. cbn. ssimpl. assumption.
+        unfold pPi. cbn. rasimpl. assumption.
       * f_equal. unfold perif. change (epm_lift ?t) with (vreg ⋅ t).
-        cbn. f_equal. f_equal. f_equal. f_equal. ssimpl. reflexivity.
+        cbn. f_equal. f_equal. f_equal. f_equal. rasimpl. reflexivity.
     + cbn in *.
       eapply param_revive_typing in h3 as hte. 2: ertype.
       cbn in hte. remd in hte. cbn in hte.
@@ -6203,10 +6167,10 @@ Proof.
       }
       eapply ccmeta_conv.
       * ertype.
-        unfold pPi. cbn. ssimpl. assumption.
+        unfold pPi. cbn. rasimpl. assumption.
       * f_equal. unfold perif. change (rpm_lift ?t) with (vreg ⋅ t).
         change (epm_lift ?t) with (vreg ⋅ t).
-        cbn. f_equal. f_equal. f_equal. f_equal. ssimpl. reflexivity.
+        cbn. f_equal. f_equal. f_equal. f_equal. rasimpl. reflexivity.
     + cbn in *. ertype.
   - cbn. rewrite epm_lift_eq. cbn.
     econstructor.
@@ -6356,12 +6320,10 @@ Proof.
               ertype. eapply ccmeta_conv.
               - ertype. eapply ccmeta_conv.
                 + ertype.
-                + cbn. lhs_ssimpl. reflexivity.
+                + cbn. rasimpl. reflexivity.
               - cbn. reflexivity.
             }
-            * cbn. lhs_ssimpl. f_equal.
-              ssimpl. rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-              reflexivity.
+            * cbn. rasimpl. reflexivity.
           + reflexivity.
         - eapply ccmeta_conv.
           + ertype.
@@ -6426,7 +6388,7 @@ Proof.
                 + ertype.
                 + reflexivity.
             }
-            * cbn. f_equal. ssimpl. reflexivity.
+            * cbn. f_equal. rasimpl. reflexivity.
           + cbn. reflexivity.
       }
       eapply param_erase_typing in h3 as hze. 2: ertype.
@@ -6476,7 +6438,7 @@ Proof.
       eapply ccmeta_conv.
       * ertype. eapply ccmeta_conv. 1: eassumption.
         f_equal. f_equal. f_equal. f_equal. f_equal. f_equal.
-        f_equal. ssimpl. reflexivity.
+        f_equal. rasimpl. reflexivity.
       * reflexivity.
     + change (relm mGhost) with false in IHh4. cbn iota in IHh4.
       change (isGhost mGhost) with true in IHh4. cbn iota in IHh4.
@@ -6946,7 +6908,7 @@ Proof.
           * eapply ccmeta_conv. 1: ertype.
             reflexivity.
           * eapply ccmeta_conv. 1: ertype.
-            cbn. f_equal. ssimpl. reflexivity.
+            cbn. f_equal. rasimpl. reflexivity.
         + reflexivity.
       - instantiate (2 := if isKind m then _ else if isProp m then _ else _).
         instantiate (1 := if isKind m then _ else if isProp m then _ else _).
@@ -6954,12 +6916,12 @@ Proof.
         all: mode_eqs. all: cbn.
         + ertype. eapply ccmeta_conv.
           * ertype. eapply ccmeta_conv. 1: ertype.
-            cbn. f_equal. ssimpl. reflexivity.
+            cbn. f_equal. rasimpl. reflexivity.
           * reflexivity.
         + ertype.
         + ertype. eapply ccmeta_conv.
           * ertype. eapply ccmeta_conv. 1: ertype.
-            cbn. f_equal. ssimpl. reflexivity.
+            cbn. f_equal. rasimpl. reflexivity.
           * reflexivity.
     }
     eapply param_revive_typing in h5 as hne. 2: ertype.
@@ -7312,7 +7274,7 @@ Proof.
                     - eapply ccmeta_conv. 1: ertype.
                       cbn. reflexivity.
                     - eapply ccmeta_conv. 1: ertype.
-                      cbn. f_equal. f_equal. ssimpl. reflexivity.
+                      cbn. f_equal. f_equal. rasimpl. reflexivity.
                     - eapply ccmeta_conv. 1: ertype.
                       reflexivity.
                   }
@@ -7337,11 +7299,11 @@ Proof.
                   }
                   1:{
                     eapply ccmeta_conv. 1: ertype.
-                    cbn. f_equal. ssimpl. reflexivity.
+                    cbn. f_equal. rasimpl. reflexivity.
                   }
                   1:{
                     eapply ccmeta_conv. 1: ertype.
-                    cbn. f_equal. f_equal. ssimpl. reflexivity.
+                    cbn. f_equal. f_equal. rasimpl. reflexivity.
                   }
                   1:{
                     eapply ccmeta_conv. 1: ertype.
@@ -7349,10 +7311,10 @@ Proof.
                   }
                   eapply ccmeta_conv. 1: ertype.
                   reflexivity.
-                + f_equal. ssimpl. rewrite !rinstInst'_cterm. reflexivity.
+                + f_equal. rasimpl. rewrite !rinstInst'_cterm. reflexivity.
             }
             * cbn. f_equal. f_equal. f_equal.
-              ssimpl. reflexivity.
+              rasimpl. reflexivity.
           + reflexivity.
       }
       cbn in *.
@@ -7412,7 +7374,7 @@ Proof.
           reflexivity.
         - eapply ccmeta_conv.
           + ertype. eapply ccmeta_conv. 1: ertype.
-            cbn. f_equal. f_equal. f_equal. ssimpl. reflexivity.
+            cbn. f_equal. f_equal. f_equal. rasimpl. reflexivity.
           + reflexivity.
         - eapply ccmeta_conv.
           + econstructor.
@@ -7424,7 +7386,7 @@ Proof.
                 + eapply ccmeta_conv. 1: ertype.
                   cbn. reflexivity.
                 + eapply ccmeta_conv. 1: ertype.
-                  cbn. f_equal. f_equal. ssimpl. reflexivity.
+                  cbn. f_equal. f_equal. rasimpl. reflexivity.
                 + eapply ccmeta_conv. 1: ertype.
                   reflexivity.
               - reflexivity.
@@ -7434,11 +7396,11 @@ Proof.
       ertype. all: try assumption.
       * eapply ccmeta_conv. 1: eassumption.
         f_equal. f_equal. f_equal. f_equal. f_equal. f_equal. f_equal.
-        ssimpl. reflexivity.
+        rasimpl. reflexivity.
       * eapply ccmeta_conv. 1: eassumption.
         f_equal. f_equal. f_equal. f_equal. f_equal. f_equal. f_equal. f_equal.
         cbn. f_equal. f_equal. f_equal. f_equal.
-        ssimpl. reflexivity.
+        rasimpl. reflexivity.
     + simpl in IHh4. erewrite !md_ren in IHh4.
       2-15: eauto using rscoping_S, rscoping_comp_S.
       remd in IHh4. cbn in IHh4.
@@ -7626,12 +7588,12 @@ Proof.
             * eapply ccmeta_conv. 1: ertype.
               reflexivity.
             * eapply ccmeta_conv. 1: ertype.
-              cbn. f_equal. f_equal. ssimpl. reflexivity.
+              cbn. f_equal. f_equal. rasimpl. reflexivity.
           + reflexivity.
         - eapply ccmeta_conv.
           + ertype. eapply ccmeta_conv.
             * ertype.
-            * cbn. f_equal. ssimpl. reflexivity.
+            * cbn. f_equal. rasimpl. reflexivity.
           + reflexivity.
         - eapply ccmeta_conv.
           + ertype. eapply ccmeta_conv.
@@ -7707,11 +7669,11 @@ Proof.
                   }
                   1:{
                     eapply ccmeta_conv. 1: ertype.
-                    cbn. f_equal. ssimpl. reflexivity.
+                    cbn. f_equal. rasimpl. reflexivity.
                   }
                   1:{
                     eapply ccmeta_conv. 1: ertype.
-                    cbn. f_equal. f_equal. ssimpl. reflexivity.
+                    cbn. f_equal. f_equal. rasimpl. reflexivity.
                   }
                   1:{
                     eapply ccmeta_conv. 1: ertype.
@@ -7855,7 +7817,7 @@ Proof.
                                         cbn. reflexivity.
                                       - eapply ccmeta_conv. 1: ertype.
                                         cbn. f_equal. f_equal.
-                                        ssimpl. reflexivity.
+                                        rasimpl. reflexivity.
                                     }
                                     * reflexivity.
                                   + eapply ccmeta_conv.
@@ -7865,9 +7827,9 @@ Proof.
                                         cbn. reflexivity.
                                       - econstructor.
                                         + eapply ccmeta_conv. 1: ertype.
-                                          cbn. f_equal. ssimpl. reflexivity.
+                                          cbn. f_equal. rasimpl. reflexivity.
                                         + eapply ccmeta_conv. 1: ertype.
-                                          cbn. f_equal. ssimpl. reflexivity.
+                                          cbn. f_equal. rasimpl. reflexivity.
                                         + eapply ccmeta_conv. 1: ertype.
                                           reflexivity.
                                     }
@@ -7892,11 +7854,11 @@ Proof.
                   }
                   * {
                     eapply ccmeta_conv. 1: ertype.
-                    cbn. f_equal. f_equal. ssimpl. reflexivity.
+                    cbn. f_equal. f_equal. rasimpl. reflexivity.
                   }
                 + cbn. reflexivity.
               - f_equal. f_equal.
-                ssimpl. rewrite rinstInst'_cterm. reflexivity.
+                rasimpl. rewrite rinstInst'_cterm. reflexivity.
             }
           + reflexivity.
       }
@@ -7961,7 +7923,7 @@ Proof.
           reflexivity.
         - eapply ccmeta_conv.
           + ertype. eapply ccmeta_conv. 1: ertype.
-            cbn. f_equal. f_equal. f_equal. ssimpl. reflexivity.
+            cbn. f_equal. f_equal. f_equal. rasimpl. reflexivity.
           + reflexivity.
         - eapply ccmeta_conv.
           + econstructor.
@@ -7973,7 +7935,7 @@ Proof.
                 + eapply ccmeta_conv. 1: ertype.
                   cbn. reflexivity.
                 + eapply ccmeta_conv. 1: ertype.
-                  cbn. f_equal. f_equal. ssimpl. reflexivity.
+                  cbn. f_equal. f_equal. rasimpl. reflexivity.
                 + eapply ccmeta_conv. 1: ertype.
                   reflexivity.
               - reflexivity.
@@ -8021,15 +7983,15 @@ Proof.
       all: try assumption.
       * eapply ccmeta_conv. 1: eassumption.
         f_equal. f_equal. f_equal. f_equal. f_equal. f_equal. f_equal.
-        ssimpl. reflexivity.
+        rasimpl. reflexivity.
       * eapply ccmeta_conv. 1: eassumption.
         unfold capps.
         f_equal. f_equal. f_equal. f_equal. f_equal. f_equal. f_equal. f_equal.
         f_equal. f_equal. f_equal. f_equal. f_equal.
-        ssimpl. reflexivity.
+        rasimpl. reflexivity.
       * unfold elength. cbn. f_equal. f_equal. f_equal. f_equal.
         f_equal. f_equal. f_equal. f_equal. f_equal. f_equal. f_equal.
-        ssimpl. reflexivity.
+        rasimpl. reflexivity.
     + simpl in IHh4. erewrite !md_ren in IHh4.
       2-7: eauto using rscoping_S, rscoping_comp_S.
       remd in IHh4. cbn in IHh4.
@@ -8131,10 +8093,10 @@ Proof.
                   * cbn. reflexivity.
                 + cbn. reflexivity.
               - cbn. eapply congr_cPi. 1,3: reflexivity.
-                f_equal. f_equal. ssimpl.
+                f_equal. f_equal. rasimpl.
                 rewrite rinstInst'_cterm. reflexivity.
             }
-            * cbn. f_equal. f_equal. ssimpl. rewrite !rinstInst'_cterm.
+            * cbn. f_equal. f_equal. rasimpl. rewrite !rinstInst'_cterm.
               reflexivity.
           + reflexivity.
         - eapply ccmeta_conv.
@@ -8162,7 +8124,7 @@ Proof.
                   * eapply ccmeta_conv. 1: ertype.
                     reflexivity.
                   * eapply ccmeta_conv. 1: ertype.
-                    cbn. f_equal. f_equal. ssimpl. reflexivity.
+                    cbn. f_equal. f_equal. rasimpl. reflexivity.
                   * eapply ccmeta_conv. 1: ertype.
                     reflexivity.
               - cbn. eapply congr_cPi. 1,3: reflexivity.
@@ -8173,7 +8135,7 @@ Proof.
             * {
               econstructor.
               - eapply ccmeta_conv. 1: ertype.
-                cbn. f_equal. ssimpl. reflexivity.
+                cbn. f_equal. rasimpl. reflexivity.
               - eapply ccmeta_conv. 1: ertype.
                 reflexivity.
               - eapply ccmeta_conv. 1: ertype.
@@ -8181,9 +8143,9 @@ Proof.
               - eapply ccmeta_conv. 1: ertype.
                 reflexivity.
               - eapply ccmeta_conv. 1: ertype.
-                cbn. f_equal. ssimpl. reflexivity.
+                cbn. f_equal. rasimpl. reflexivity.
               - eapply ccmeta_conv. 1: ertype.
-                cbn. f_equal. f_equal. ssimpl.
+                cbn. f_equal. f_equal. rasimpl.
                 reflexivity.
               - eapply ccmeta_conv. 1: ertype.
                 reflexivity.

--- a/theories/Revival.v
+++ b/theories/Revival.v
@@ -163,7 +163,7 @@ Proof.
   }
   eexists. split.
   - eassumption.
-  - ssimpl. reflexivity.
+  - rasimpl. reflexivity.
 Qed.
 
 Lemma scoping_to_rev :
@@ -183,7 +183,7 @@ Lemma conv_to_rev :
 Proof.
   intros Γ u v h.
   eapply cconv_ren in h. 2: eapply typing_sub_rev.
-  revert h. ssimpl. auto.
+  revert h. rasimpl. auto.
 Qed.
 
 Lemma type_to_rev :
@@ -193,7 +193,7 @@ Lemma type_to_rev :
 Proof.
   intros Γ u v h.
   eapply ctyping_ren in h. 2: eapply typing_sub_rev.
-  revert h. ssimpl. auto.
+  revert h. rasimpl. auto.
 Qed.
 
 (** Revival of context and of variables **)
@@ -283,14 +283,14 @@ Lemma revive_ren :
 Proof.
   intros Γ Δ ρ t hρ hcρ.
   induction t in Γ, Δ, ρ, hρ, hcρ |- *.
-  all: try solve [ asimpl ; cbn ; eauto ].
+  all: try solve [ rasimpl ; cbn ; eauto ].
   - cbn.
     unfold ghv.
     destruct (nth_error Δ n) eqn:e.
     + eapply hρ in e. rewrite e.
       destruct (isGhost m). all: reflexivity.
     + eapply hcρ in e. rewrite e. reflexivity.
-  - cbn. ssimpl.
+  - cbn. rasimpl.
     erewrite IHt2.
     2:{ eapply rscoping_upren. eassumption. }
     2:{ eapply rscoping_comp_upren. assumption. }
@@ -299,7 +299,7 @@ Proof.
     2:{ eapply rscoping_comp_upren. eassumption. }
     destruct_ifs. 3: reflexivity.
     + unfold close. ssimpl. reflexivity.
-    + ssimpl. f_equal. erewrite erase_ren. 2,3: eassumption.
+    + rasimpl. f_equal. erewrite erase_ren. 2,3: eassumption.
       reflexivity.
   - cbn.
     erewrite IHt1. 2,3: eassumption.
@@ -307,7 +307,7 @@ Proof.
     erewrite md_ren. 2,3: eassumption.
     erewrite md_ren. 2,3: eassumption.
     destruct_ifs. all: try solve [ eauto ].
-    ssimpl. f_equal.
+    rasimpl. f_equal.
     erewrite erase_ren. 2,3: eassumption.
     reflexivity.
   - cbn.
@@ -321,7 +321,7 @@ Proof.
   - cbn. destruct_ifs. 2: eauto.
     cbn. erewrite IHt3, IHt4. 2-5: eassumption.
     erewrite !erase_ren. 2-5: eassumption.
-    f_equal. ssimpl. reflexivity.
+    f_equal. rasimpl. reflexivity.
   - cbn. destruct_ifs. 2: eauto.
     cbn. erewrite IHt3, IHt4. 2-5: eassumption.
     erewrite !erase_ren. 2-5: eassumption.
@@ -329,7 +329,7 @@ Proof.
   - cbn. destruct_ifs. 2: eauto.
     cbn. erewrite IHt5, IHt6. 2-5: eassumption.
     erewrite !erase_ren. 2-7: eassumption.
-    unfold elength. ssimpl. reflexivity.
+    unfold elength. rasimpl. reflexivity.
   - cbn.
     destruct_ifs. 2: eauto.
     erewrite erase_ren. 2,3: eassumption.
@@ -364,8 +364,8 @@ Lemma revive_subst :
 Proof.
   intros Γ Δ σ t hσ hcσ.
   induction t in Γ, Δ, σ, hσ, hcσ |- *.
-  all: try solve [ asimpl ; cbn ; eauto ].
-  - ssimpl. cbn. unfold ghv. unfold rev_subst. destruct (nth_error Δ n) eqn:e.
+  all: try solve [ rasimpl ; cbn ; eauto ].
+  - rasimpl. cbn. unfold ghv. unfold rev_subst. destruct (nth_error Δ n) eqn:e.
     + destruct (isGhost m) eqn:em.
       * cbn. unfold ghv. rewrite e. rewrite em. reflexivity.
       * cbn. eapply revive_ng. clear hcσ.
@@ -382,32 +382,32 @@ Proof.
   - cbn.
     erewrite md_subst.
     2:{ eapply sscoping_shift. eassumption. }
-    2:{ ssimpl. eapply sscoping_comp_shift. assumption. }
+    2:{ rasimpl. eapply sscoping_comp_shift. assumption. }
     erewrite erase_subst. 2,3: eassumption.
     erewrite IHt2.
     2:{ eapply sscoping_shift. eassumption. }
-    2:{ ssimpl. eapply sscoping_comp_shift. assumption. }
+    2:{ rasimpl. eapply sscoping_comp_shift. assumption. }
     destruct_ifs.
     + destruct m. all: try discriminate.
-      unfold close. ssimpl.
+      unfold close. rasimpl.
       eapply ext_cterm. intros [].
       * cbn. reflexivity.
-      * cbn. unfold rev_subst. ssimpl. unfold ghv. cbn.
+      * cbn. unfold rev_subst. rasimpl. unfold ghv. cbn.
         destruct (nth_error Δ n) eqn:e1.
         -- destruct_if e2.
           ++ ssimpl. erewrite revive_ren.
             2:{ eapply rscoping_S. }
             2:{ eapply rscoping_comp_S. }
-            ssimpl. reflexivity.
+            rasimpl. reflexivity.
           ++ ssimpl. erewrite erase_ren.
             2:{ eapply rscoping_S. }
             2:{ eapply rscoping_comp_S. }
-            ssimpl. reflexivity.
+            rasimpl. reflexivity.
         -- ssimpl. erewrite erase_ren.
           2:{ eapply rscoping_S. }
           2:{ eapply rscoping_comp_S. }
-          ssimpl. reflexivity.
-    + cbn. ssimpl. f_equal.
+          rasimpl. reflexivity.
+    + cbn. rasimpl. f_equal.
       * f_equal. eapply erase_rev_subst.
       * eapply ext_cterm. intros [].
         -- cbn. unfold rev_subst. unfold ghv. cbn.
@@ -436,7 +436,7 @@ Proof.
     erewrite IHt1. 2,3: eauto.
     erewrite IHt2. 2,3: eauto.
     destruct_ifs.
-    + cbn. ssimpl. f_equal. erewrite erase_subst. 2,3: eassumption.
+    + cbn. rasimpl. f_equal. erewrite erase_subst. 2,3: eassumption.
       apply erase_rev_subst.
     + cbn. reflexivity.
     + reflexivity.
@@ -449,14 +449,14 @@ Proof.
     destruct_ifs. 2: reflexivity.
     erewrite IHt1. 2,3: eassumption.
     erewrite IHt3. 2,3: eassumption.
-    ssimpl. reflexivity.
+    rasimpl. reflexivity.
   - cbn.
     erewrite IHt3. 2,3: eassumption.
     erewrite IHt4. 2,3: eassumption.
     erewrite !erase_subst. 2-5: eassumption.
     rewrite !erase_rev_subst.
     destruct_if eg. 2: reflexivity.
-    cbn. f_equal. ssimpl. reflexivity.
+    cbn. f_equal. rasimpl. reflexivity.
   - cbn.
     erewrite IHt3. 2,3: eassumption.
     erewrite IHt4. 2,3: eassumption.
@@ -468,7 +468,7 @@ Proof.
     erewrite !erase_subst. 2-7: eassumption.
     rewrite !erase_rev_subst.
     destruct_if eg. 2: reflexivity.
-    cbn. unfold elength. ssimpl. reflexivity.
+    cbn. unfold elength. rasimpl. reflexivity.
   - cbn.
     destruct_ifs. 2: reflexivity.
     erewrite erase_subst. 2,3: eassumption.
@@ -493,7 +493,7 @@ Proof.
       erewrite revive_subst.
       2: eapply sscoping_one. 2: eassumption.
       2: eapply sscoping_comp_one.
-      ssimpl. eapply ext_cterm_scoped. 1: eapply revive_scoping.
+      rasimpl. eapply ext_cterm_scoped. 1: eapply revive_scoping.
       unfold rev_subst. unfold ghv.
       intros [| x] ex.
       * cbn. destruct_if e2. 1:{ mode_eqs. discriminate. }
@@ -513,7 +513,7 @@ Proof.
       erewrite revive_subst.
       2: eapply sscoping_one. 2: eassumption.
       2: eapply sscoping_comp_one.
-      ssimpl. eapply ext_cterm_scoped. 1: eapply revive_scoping.
+      rasimpl. eapply ext_cterm_scoped. 1: eapply revive_scoping.
       unfold rev_subst. unfold ghv.
       intros [| x] ex.
       * cbn. reflexivity.
@@ -531,7 +531,7 @@ Proof.
     + unfold close. erewrite revive_subst.
       2: eapply sscoping_one. 2: eassumption.
       2: eapply sscoping_comp_one.
-      ssimpl. apply ccmeta_refl.
+      rasimpl. apply ccmeta_refl.
       eapply ext_cterm_scoped. 1: eapply revive_scoping.
       intros [| x] ex.
       1:{ unfold inscope in ex. cbn in ex. discriminate. }
@@ -586,7 +586,7 @@ Proof.
       constructor. 2: econv.
       constructor. 2: econv.
       eapply cconv_trans. 1: constructor.
-      cbn. lhs_ssimpl. econv.
+      cbn. rasimpl. econv.
     }
     eapply cconv_trans.
     1:{
@@ -596,8 +596,8 @@ Proof.
     }
     erewrite !erase_ren. 2-7: eauto using rscoping_S, rscoping_comp_S.
     econv.
-    + ssimpl. econv.
-    + ssimpl. rewrite <- rinstInst'_cterm. econv.
+    + rasimpl. econv.
+    + rasimpl. econv.
     + apply cconv_sym. eapply cconv_trans.
       1:{
         constructor. 2: econv.
@@ -803,23 +803,23 @@ Proof.
               cbn in h2. rewrite e in h2. eassumption.
             ** constructor.
             ** eauto with cc_type.
-    + ssimpl. erewrite ext_cterm_scoped with (θ := ids).
+    + rasimpl. erewrite ext_cterm_scoped with (θ := ids).
       2: eapply erase_scoping.
       2:{
         intros [] ex.
         - cbn. discriminate.
-        - cbn. ssimpl. reflexivity.
+        - cbn. rasimpl. reflexivity.
       }
-      ssimpl.
-      unfold nones. ssimpl.
+      rasimpl.
+      unfold nones. rasimpl.
       erewrite ext_cterm_scoped with (θ := ids).
       2: eapply erase_scoping.
       2:{
         intros [] ex.
         - cbn. discriminate.
-        - cbn. ssimpl. reflexivity.
+        - cbn. rasimpl. reflexivity.
       }
-      ssimpl.
+      rasimpl.
       econstructor.
       * econstructor.
         -- econstructor. econstructor.
@@ -925,23 +925,23 @@ Proof.
         -- eauto with cc_type.
     + cbn in IHh1.
       revert IHh1.
-      ssimpl. erewrite ext_cterm_scoped with (θ := ids).
+      rasimpl. erewrite ext_cterm_scoped with (θ := ids).
       2: eapply erase_scoping.
       2:{
         intros [] ex.
         - cbn. discriminate.
-        - cbn. ssimpl. reflexivity.
+        - cbn. rasimpl. reflexivity.
       }
-      ssimpl.
-      unfold nones. ssimpl.
+      rasimpl.
+      unfold nones. rasimpl.
       erewrite ext_cterm_scoped with (θ := ids).
       2: eapply erase_scoping.
       2:{
         intros [] ex.
         - cbn. discriminate.
-        - cbn. ssimpl. reflexivity.
+        - cbn. rasimpl. reflexivity.
       }
-      ssimpl. intro ih.
+      rasimpl. intro ih.
       econstructor.
       * econstructor.
         -- econstructor.
@@ -996,7 +996,7 @@ Proof.
         unfold close. erewrite erase_subst.
         2:{ eapply sscoping_one. eassumption. }
         2: eapply sscoping_comp_one.
-        ssimpl. eapply ext_cterm_scoped. 1: eapply erase_scoping.
+        rasimpl. eapply ext_cterm_scoped. 1: eapply erase_scoping.
         intros [] ex.
         -- cbn in ex. rewrite e in ex. discriminate.
         -- cbn. unfold relv. unfold inscope in ex. unfold erase_sc in ex.
@@ -1065,11 +1065,11 @@ Proof.
               constructor.
             ** eauto with cc_type.
       * eauto.
-    + ssimpl. apply ccmeta_refl.
+    + rasimpl. apply ccmeta_refl.
       erewrite erase_ren.
       2: eapply rscoping_S.
       2: eapply rscoping_comp_S.
-      ssimpl. reflexivity.
+      rasimpl. reflexivity.
     + eapply erase_typing in h2.
       2:{
         cbn.
@@ -1129,7 +1129,7 @@ Proof.
         econstructor.
         - eauto.
         - apply cconv_sym. eapply cconv_trans. 1: constructor.
-          cbn. ssimpl. apply cconv_refl.
+          cbn. rasimpl. apply cconv_refl.
         - eapply ccmeta_conv.
           + econstructor. 2: eauto with cc_type.
             econstructor. 1: etype.
@@ -1148,7 +1148,7 @@ Proof.
         econstructor.
         - eauto.
         - apply cconv_sym. eapply cconv_trans. 1: constructor.
-          cbn. ssimpl. apply cconv_refl.
+          cbn. rasimpl. apply cconv_refl.
         - eapply ccmeta_conv.
           + econstructor. 2: eauto with cc_type.
             econstructor. 1: etype.
@@ -1169,7 +1169,7 @@ Proof.
           + etype.
           + cbn. reflexivity.
         - apply cconv_sym. eapply cconv_trans. 1: constructor.
-          cbn. ssimpl. apply cconv_refl.
+          cbn. rasimpl. apply cconv_refl.
         - eapply ccmeta_conv.
           + etype. eapply ccmeta_conv.
             * {
@@ -1183,7 +1183,7 @@ Proof.
           + cbn. reflexivity.
       }
     + eapply cconv_trans. 1: constructor.
-      cbn. ssimpl. apply cconv_refl.
+      cbn. rasimpl. apply cconv_refl.
     + etype. eapply ccmeta_conv.
       * etype.
       * cbn. reflexivity.
@@ -1229,7 +1229,7 @@ Proof.
           * {
             eapply ccmeta_conv.
             - eapply ctyping_ren. 1: apply crtyping_S.
-              tm_ssimpl. rewrite <- rinstInst'_cterm.
+              rasimpl.
               eapply ctyping_ren. 1: apply crtyping_S.
               eauto.
             - cbn. reflexivity.
@@ -1242,7 +1242,7 @@ Proof.
         + reflexivity.
     }
     etype. 1: reflexivity.
-    revert IHh4. ssimpl. rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
+    revert IHh4. rasimpl.
     auto.
   - cbn in hm. subst.
     cbn. remd. cbn.
@@ -1259,7 +1259,7 @@ Proof.
       eapply cconv_trans. 1: constructor.
       constructor.
       - erewrite erase_ren. 2,3: eauto using rscoping_S, rscoping_comp_S.
-        lhs_ssimpl. econv.
+        rasimpl. econv.
       - constructor.
     }
     2: etype.
@@ -1279,20 +1279,17 @@ Proof.
       erewrite !erase_ren. 2-19: eauto using rscoping_S, rscoping_comp_S.
       constructor.
       1:{
-        apply ccmeta_refl. lhs_ssimpl.
-        rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
+        apply ccmeta_refl. rasimpl.
         reflexivity.
       }
       eapply cconv_trans. 1: constructor.
       constructor.
       1:{
-        apply ccmeta_refl. lhs_ssimpl.
-        rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
+        apply ccmeta_refl. rasimpl.
         reflexivity.
       }
-      apply ccmeta_refl. lhs_ssimpl. cbn. lhs_ssimpl.
+      apply ccmeta_refl. rasimpl. cbn. rasimpl.
       unfold shift.
-      rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
       reflexivity.
     }
     2:{
@@ -1305,7 +1302,7 @@ Proof.
         + ertype. 2: reflexivity.
           eapply ccmeta_conv.
           * ertype.
-          * cbn. f_equal. ssimpl. reflexivity.
+          * cbn. f_equal. rasimpl. reflexivity.
         + reflexivity.
       - eapply ccmeta_conv.
         + econstructor.
@@ -1318,7 +1315,7 @@ Proof.
               + cbn. reflexivity.
             - eapply ccmeta_conv.
               + ertype. reflexivity.
-              + cbn. f_equal. ssimpl. reflexivity.
+              + cbn. f_equal. rasimpl. reflexivity.
             - eapply ccmeta_conv.
               + ertype.
               + reflexivity.
@@ -1341,7 +1338,7 @@ Proof.
             eapply ccmeta_conv. 1: ertype.
             cbn. reflexivity.
           + cbn. econv. apply cconv_sym. econv.
-          + tm_ssimpl. ertype.
+          + rasimpl. ertype.
             * {
               eapply ccmeta_conv.
               - ertype.
@@ -1349,22 +1346,19 @@ Proof.
                   reflexivity.
                 + eapply ccmeta_conv.
                   * ertype. reflexivity.
-                  * cbn. ssimpl. reflexivity.
+                  * cbn. rasimpl. reflexivity.
               - reflexivity.
             }
-            * rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-              eapply ccmeta_conv. 1: ertype.
+            * eapply ccmeta_conv. 1: ertype.
               reflexivity.
             * {
-              rewrite <- !funcomp_assoc. rewrite <- !rinstInst'_cterm.
               eapply ccmeta_conv.
               - ertype. 2: reflexivity.
                 eapply ccmeta_conv. 1: ertype.
-                cbn. f_equal. f_equal. f_equal. ssimpl. reflexivity.
+                cbn. f_equal. f_equal. f_equal. rasimpl. reflexivity.
               - reflexivity.
             }
             * {
-              rewrite <- !funcomp_assoc. rewrite <- !rinstInst'_cterm.
               eapply ccmeta_conv.
               - econstructor.
                 + eapply ccmeta_conv. 1: ertype.
@@ -1378,7 +1372,7 @@ Proof.
                   * {
                     eapply ccmeta_conv.
                     - ertype. reflexivity.
-                    - cbn. f_equal. f_equal. ssimpl. reflexivity.
+                    - cbn. f_equal. f_equal. rasimpl. reflexivity.
                   }
                   * eapply ccmeta_conv. 1: ertype.
                     reflexivity.
@@ -1386,7 +1380,7 @@ Proof.
             }
         - eapply ccmeta_conv.
           + ertype. reflexivity.
-          + cbn. f_equal. f_equal. ssimpl. reflexivity.
+          + cbn. f_equal. f_equal. rasimpl. reflexivity.
         - eapply ccmeta_conv. 1: ertype.
           reflexivity.
         - econstructor.
@@ -1418,7 +1412,7 @@ Proof.
                   reflexivity.
                 + eapply ccmeta_conv.
                   * ertype. reflexivity.
-                  * cbn. f_equal. f_equal. ssimpl. reflexivity.
+                  * cbn. f_equal. f_equal. rasimpl. reflexivity.
               - reflexivity.
             }
             * {
@@ -1431,7 +1425,7 @@ Proof.
                   * reflexivity.
                 + eapply ccmeta_conv.
                   * ertype. reflexivity.
-                  * cbn. f_equal. f_equal. ssimpl. reflexivity.
+                  * cbn. f_equal. f_equal. rasimpl. reflexivity.
                 + eapply ccmeta_conv. 1: ertype.
                   reflexivity.
               - reflexivity.
@@ -1439,11 +1433,10 @@ Proof.
         - eapply ccmeta_conv. 1: ertype.
           reflexivity.
       }
-      * cbn. f_equal. ssimpl. rewrite <- !funcomp_assoc.
-        rewrite <- rinstInst'_cterm. reflexivity.
+      * cbn. f_equal. rasimpl. reflexivity.
     + cbn. f_equal. all: f_equal. all: f_equal.
-      * ssimpl. rewrite rinstInst'_cterm. reflexivity.
-      * ssimpl. rewrite rinstInst'_cterm. reflexivity.
+      * rasimpl. rewrite rinstInst'_cterm. reflexivity.
+      * rasimpl. rewrite rinstInst'_cterm. reflexivity.
   - cbn.
     cbn in hm. subst. cbn.
     eapply erase_typing in h1.

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -41,6 +41,8 @@ Ltac ssimpl :=
   - If an expression is under a binder and uses the bound variable, then rasimpl
     is unable to do anything. I don't see a way to avoid using setoid_rewrite
     there.
+    ⇒ Maybe by using meta-variables instead of "atoms" so that rewrite doesn't
+      have to touch the local variables.
   - Also it cannot currently rewrite under new custom contexts.
 
   Ways to improve:

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -44,6 +44,8 @@ Ltac ssimpl :=
     ⇒ Maybe by using meta-variables instead of "atoms" so that rewrite doesn't
       have to touch the local variables.
   - Also it cannot currently rewrite under new custom contexts.
+  - Because I still need to use asimpl sometimes, and they don't normalise
+    exactly the same, there might be a mismatch.
 
   Ways to improve:
   - Maybe the traversal isn't optimal, some subterms might be quoted and

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -662,7 +662,7 @@ Ltac asimpl_unfold :=
     Up_cterm_cterm, Up_cterm, up_cterm, Subst_cterm, Subst1,
     subst1,
     (* Added myself *)
-    upRen_cterm_cterm, up_ren.
+    upRen_cterm_cterm, up_ren, up_cterm_cterm, var_zero.
 
 Ltac asimpl_unfold_in h :=
   unfold
@@ -671,7 +671,7 @@ Ltac asimpl_unfold_in h :=
     Up_cterm_cterm, Up_cterm, up_cterm, Subst_cterm, Subst1,
     subst1,
     (* Added myself *)
-    upRen_cterm_cterm, up_ren
+    upRen_cterm_cterm, up_ren, up_cterm_cterm, var_zero
   in h.
 
 Ltac asimpl_unfold_all :=
@@ -681,7 +681,7 @@ Ltac asimpl_unfold_all :=
     Up_cterm_cterm, Up_cterm, up_cterm, Subst_cterm, Subst1,
     subst1,
     (* Added myself *)
-    upRen_cterm_cterm, up_ren
+    upRen_cterm_cterm, up_ren, up_cterm_cterm, var_zero
   in *.
 
 Tactic Notation "aunfold" := asimpl_unfold.
@@ -700,7 +700,7 @@ Ltac rasimpl1_t t :=
     unquote_nat
     ren_cterm subst_cterm scons
   ] ;
-  unfold upRen_cterm_cterm, up_ren. (* Maybe aunfold? *)
+  unfold upRen_cterm_cterm, up_ren, up_cterm_cterm, var_zero. (* Maybe aunfold? *)
 
 Ltac rasimpl1_aux g :=
   first [

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -224,5 +224,21 @@ Ltac rasimpl1 :=
     ]
   end.
 
-Ltac rasimpl :=
+Ltac rasimpl' :=
   repeat rasimpl1.
+
+Ltac rasimpl :=
+  repeat
+    unfold
+      VarInstance_cterm, Var, ids, Ren_cterm, Ren1, ren1,
+      Up_cterm_cterm, Up_cterm, up_cterm, Subst_cterm, Subst1,
+      subst1 in * ;
+  rasimpl' ;
+  minimize.
+
+Ltac rssimpl :=
+  rasimpl ;
+  autosubst_unfold ;
+  rasimpl ;
+  resubst ;
+  rasimpl.

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -50,6 +50,8 @@ Ltac ssimpl :=
   - An NbE approach would be nice.
   - Ideally, we could do much more in one step if we could incude all rules
     pertaining to constructors of the syntax, but this should be generated.
+  - shift could be shiftn instead, as we often need those, better than using
+    addn manually, and the tactic could handle those easily.
 
 **)
 

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -571,6 +571,30 @@ Ltac asimpl_unfold :=
     (* Added myself *)
     upRen_cterm_cterm, up_ren.
 
+Ltac asimpl_unfold_in h :=
+  unfold
+    (* Taken from asimpl *)
+    VarInstance_cterm, Var, ids, Ren_cterm, Ren1, ren1,
+    Up_cterm_cterm, Up_cterm, up_cterm, Subst_cterm, Subst1,
+    subst1,
+    (* Added myself *)
+    upRen_cterm_cterm, up_ren
+  in h.
+
+Ltac asimpl_unfold_all :=
+  unfold
+    (* Taken from asimpl *)
+    VarInstance_cterm, Var, ids, Ren_cterm, Ren1, ren1,
+    Up_cterm_cterm, Up_cterm, up_cterm, Subst_cterm, Subst1,
+    subst1,
+    (* Added myself *)
+    upRen_cterm_cterm, up_ren
+  in *.
+
+Tactic Notation "aunfold" := asimpl_unfold.
+Tactic Notation "aunfold" "in" hyp(h) := asimpl_unfold_in h.
+Tactic Notation "aunfold" "in" "*" := asimpl_unfold_all.
+
 Ltac rasimpl :=
   repeat asimpl_unfold ;
   minimize ;

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -511,9 +511,18 @@ Ltac rasimpl1_t t :=
     ren_cterm subst_cterm
   ].
 
+Ltac rasimpl1_aux g :=
+  first [
+    progress (rasimpl1_t g)
+  | lazymatch g with
+    | ?f ?u => rasimpl1_aux f ; rasimpl1_aux u
+    end
+  | idtac
+  ].
+
 Ltac rasimpl1 :=
-  match goal with
-  | |- context G[ ?t ] => progress (rasimpl1_t t)
+  lazymatch goal with
+  | |- ?g => rasimpl1_aux g
   end.
 
 Ltac rasimpl' :=

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -165,6 +165,7 @@ Inductive eval_subst_comp_view : quoted_subst → quoted_subst → Type :=
 | es_id_l s : eval_subst_comp_view qsubst_id s
 | es_id_r s : eval_subst_comp_view s qsubst_id
 | es_comp_r s u v : eval_subst_comp_view s (qsubst_comp u v)
+| es_compr_r s x y : eval_subst_comp_view s (qsubst_compr x y)
 | es_cons_r s t s' : eval_subst_comp_view s (qsubst_cons t s')
 | es_ren_r s r : eval_subst_comp_view s (qsubst_ren r)
 | es_other u v : eval_subst_comp_view u v.
@@ -174,6 +175,7 @@ Definition eval_subst_comp_c u v : eval_subst_comp_view u v :=
   | qsubst_id, v => es_id_l v
   | u, qsubst_id => es_id_r u
   | u, qsubst_comp x y => es_comp_r u x y
+  | u, qsubst_compr x y => es_compr_r u x y
   | u, qsubst_cons t s => es_cons_r u t s
   | u, qsubst_ren r => es_ren_r u r
   | u, v => es_other u v
@@ -218,6 +220,7 @@ Fixpoint eval_subst (s : quoted_subst) : quoted_subst :=
     | es_id_l v => v
     | es_id_r u => u
     | es_comp_r u x y => qsubst_comp (qsubst_comp u x) y
+    | es_compr_r u x y => qsubst_compr (qsubst_comp u x) y
     | es_cons_r u t s => qsubst_cons (subst_cterm (unquote_subst u) t) (qsubst_comp u s)
     | es_ren_r u r => qsubst_compr u r
     | es_other u v => qsubst_comp u v
@@ -384,6 +387,9 @@ Proof.
         eapply subst_cterm_morphism. 1: eassumption.
         reflexivity.
       }
+      asimpl. reflexivity.
+    + cbn in *. unfold funcomp in *.
+      erewrite subst_cterm_morphism. 2,3: eauto.
       asimpl. reflexivity.
     + cbn in *. unfold funcomp in *.
       erewrite subst_cterm_morphism. 2,3: eauto.

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -303,14 +303,14 @@ Fixpoint eval_cterm (t : quoted_cterm) : quoted_cterm :=
     let r := eval_ren r in
     let t := eval_cterm t in
     match t with
-    | qren r' t => qren (qren_comp r' r) t
+    | qren r' t => qren (qren_comp r r') t
     | _ => qren r t
     end
   | qsubst s t =>
     let s := eval_subst s in
     let t := eval_cterm t in
     match t with
-    | qsubst s' t => qsubst (qsubst_comp s' s) t
+    | qsubst s' t => qsubst (qsubst_comp s s') t
     | qren r t => qsubst (qsubst_compr s r) t
     | _ => qsubst s t
     end
@@ -469,7 +469,34 @@ Lemma eval_cterm_sound :
   ∀ t,
     unquote_cterm t = unquote_cterm (eval_cterm t).
 Proof.
-Admitted.
+  intros t.
+  induction t.
+  - reflexivity.
+  - cbn. remember (eval_cterm _) as et eqn:e in *.
+    destruct et.
+    + cbn. rewrite IHt. cbn.
+      eapply ren_cterm_morphism. 2: reflexivity.
+      intro. apply eval_ren_sound.
+    + cbn. rewrite IHt. cbn. rewrite renRen_cterm.
+      apply ren_cterm_morphism. 2: reflexivity.
+      intro. unfold funcomp. rewrite <- eval_ren_sound. reflexivity.
+    + cbn. rewrite IHt. cbn.
+      eapply ren_cterm_morphism. 2: reflexivity.
+      intro. apply eval_ren_sound.
+  - cbn. remember (eval_cterm _) as et eqn:e in *.
+    destruct et.
+    + cbn. rewrite IHt. cbn.
+      eapply subst_cterm_morphism. 2: reflexivity.
+      intro. apply eval_subst_sound.
+    + cbn. rewrite IHt. cbn. rewrite renSubst_cterm.
+      apply subst_cterm_morphism. 2: reflexivity.
+      intro. unfold funcomp. rewrite <- eval_subst_sound. reflexivity.
+    + cbn. rewrite IHt. cbn. rewrite substSubst_cterm.
+      eapply subst_cterm_morphism. 2: reflexivity.
+      intro. unfold funcomp.
+      eapply subst_cterm_morphism. 2: reflexivity.
+      intro. rewrite <- eval_subst_sound. reflexivity.
+Qed.
 
 (** Quoting **)
 

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -235,6 +235,7 @@ Fixpoint eval_cterm (t : quoted_cterm) : quoted_cterm :=
     let r := eval_ren r in
     let t := eval_cterm t in
     match t with
+    | qsubst s t => qsubst (qsubst_comp (qsubst_ren r) s) t
     | qren r' t => qren (qren_comp r r') t
     | _ => qren r t
     end
@@ -404,8 +405,13 @@ Proof.
       apply ren_cterm_morphism. 2: reflexivity.
       intro. unfold funcomp. rewrite <- eval_ren_sound. reflexivity.
     + cbn. rewrite IHt. cbn.
-      eapply ren_cterm_morphism. 2: reflexivity.
-      intro. apply eval_ren_sound.
+      rewrite substRen_cterm.
+      apply subst_cterm_morphism. 2: reflexivity.
+      intro. unfold funcomp.
+      rewrite rinstInst'_cterm.
+      apply subst_cterm_morphism. 2: reflexivity.
+      intro. unfold funcomp.
+      rewrite <- eval_ren_sound. reflexivity.
   - cbn. remember (eval_cterm _) as et eqn:e in *.
     destruct et.
     + cbn. rewrite IHt. cbn.
@@ -515,6 +521,8 @@ Ltac rasimpl1_aux g :=
   first [
     progress (rasimpl1_t g)
   | lazymatch g with
+    | subst_cterm ?s _ => rasimpl1_aux s
+    | ren_cterm ?r _ => rasimpl1_aux r
     | ?f ?u => rasimpl1_aux f ; rasimpl1_aux u
     end
   | idtac

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -512,6 +512,7 @@ Ltac quote_subst s :=
     let q := quote_subst s in
     constr:(qsubst_cons t q)
   | ids => constr:(qsubst_id)
+  | cvar => constr:(qsubst_id)
   | _ => constr:(qsubst_atom s)
   end.
 

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -35,7 +35,22 @@ Ltac ssimpl :=
   asimpl ;
   repeat unfold_funcomp.
 
-(** Autosubst reflective tactic that should be more efficient than asimpl **)
+(** Autosubst reflective tactic that should be more efficient than asimpl
+
+  Downsides:
+  - If an expression is under a binder and uses the bound variable, then rasimpl
+    is unable to do anything. I don't see a way to avoid using setoid_rewrite
+    there.
+
+  Ways to improve:
+  - Maybe the traversal isn't optimal, some subterms might be quoted and
+    unquoted many times unnecessarily.
+  - Maybe treatment of var, ids, and renamings as substitutions.
+  - An NbE approach would be nice.
+  - Ideally, we could do much more in one step if we could incude all rules
+    pertaining to constructors of the syntax, but this should be generated.
+
+**)
 
 Inductive quoted_nat :=
 | qnat_atom (n : nat)
@@ -574,7 +589,8 @@ Ltac rasimpl1_t t :=
     unquote_subst eval_subst eval_subst_compr_c eval_subst_comp_c
     unquote_nat
     ren_cterm subst_cterm scons
-  ].
+  ] ;
+  unfold upRen_cterm_cterm, up_ren. (* Maybe aunfold? *)
 
 Ltac rasimpl1_aux g :=
   first [

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -532,6 +532,12 @@ Ltac quote_ren r :=
 
 Ltac quote_subst s :=
   lazymatch s with
+  | funcomp cvar ?r =>
+    let q := quote_ren r in
+    constr:(qsubst_ren q)
+  | λ x, cvar (?r x) =>
+    let q := quote_ren r in
+    constr:(qsubst_ren q)
   | funcomp (subst_cterm ?s) ?t =>
     let q := quote_subst s in
     let q' := quote_subst t in
@@ -552,28 +558,15 @@ Ltac quote_subst s :=
     let q := quote_subst s in
     constr:(qsubst_cons t q)
   | ids => constr:(qsubst_id)
-  | _ =>
-    first [
-      let q := quote_ren s in
-      constr:(qsubst_ren q)
-    | constr:(qsubst_atom s)
-    ]
+  | _ => constr:(qsubst_atom s)
   end.
 
 Ltac quote_cterm t :=
   lazymatch t with
-  | ren1 ?r ?t =>
-    let qr := quote_ren r in
-    let qt := quote_cterm t in
-    constr:(qren qr qt)
   | ren_cterm ?r ?t =>
     let qr := quote_ren r in
     let qt := quote_cterm t in
     constr:(qren qr qt)
-  | subst1 ?s ?t =>
-    let qs := quote_subst s in
-    let qt := quote_cterm t in
-    constr:(qsubst qs qt)
   | subst_cterm ?s ?t =>
     let qs := quote_subst s in
     let qt := quote_cterm t in
@@ -588,9 +581,9 @@ Ltac rasimpl1_t t :=
   change t with (unquote_cterm q) ;
   rewrite eval_cterm_sound ;
   cbn [
-    unquote_cterm eval_cterm
-    unquote_ren eval_ren
-    unquote_subst eval_subst
+    unquote_cterm eval_cterm test_qren_id
+    unquote_ren eval_ren apply_ren
+    unquote_subst eval_subst eval_subst_compr_c eval_subst_comp_c
     unquote_nat
     ren_cterm subst_cterm
   ].
@@ -606,9 +599,12 @@ Ltac rasimpl' :=
 Ltac rasimpl :=
   repeat
     unfold
+      (* Taken from asimpl *)
       VarInstance_cterm, Var, ids, Ren_cterm, Ren1, ren1,
       Up_cterm_cterm, Up_cterm, up_cterm, Subst_cterm, Subst1,
-      subst1 in * ;
+      subst1,
+      (* Added myself *)
+      upRen_cterm_cterm, up_ren ;
   minimize ;
   rasimpl' ;
   minimize.

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -129,7 +129,24 @@ Fixpoint eval_ren (r : quoted_ren) :=
   | _ => r
   end.
 
-Inductive eval_ren_view : quoted_ren → Type :=
+(* Equations eval_ren (r : quoted_ren) : quoted_ren :=
+  eval_ren qr with qr := {
+  | qren_comp r q with eval_ren r, eval_ren q := {
+    | qren_id, _ => q
+    | _, qren_id => r
+    | qren_cons n r', qren_shift => r'
+    | _, qren_comp u v => qren_comp (qren_comp r u) v
+    | _, qren_cons n q' => qren_cons (apply_ren r n) (qren_comp r q')
+    | _, _ => qren_comp r q
+    }
+  | qren_cons q0 qren_shift => qren_id
+  | qren_cons n r with eval_ren r := {
+    | r' => qren_cons n r
+    }
+  | _ => qr
+  }. *)
+
+(* Inductive eval_ren_view : quoted_ren → Type :=
 | eval_ren_comp r q : eval_ren_view (qren_comp r q)
 | eval_ren_cons_0_shift : eval_ren_view (qren_cons q0 qren_shift)
 | eval_ren_cons n r : eval_ren_view (qren_cons n r)
@@ -159,7 +176,7 @@ Definition eval_ren_comp_c r q : eval_ren_comp_view r q :=
   | r, qren_comp u v => eval_ren_comp_r r u v
   | r, qren_cons n q => eval_ren_cons_r r n q
   | r, q =>  eval_ren_comp_other r q
-  end.
+  end. *)
 
 (* Equations eval_ren (r : quoted_ren) : quoted_ren :=
   eval_ren r with eval_ren_c r := {

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -577,6 +577,14 @@ Ltac rasimpl :=
   rasimpl' ;
   minimize.
 
+Ltac rasimpl_in h :=
+  revert h ;
+  rasimpl ;
+  intro h.
+
+Tactic Notation "rasimpl" "in" hyp(h) :=
+  rasimpl_in h.
+
 Ltac rssimpl :=
   rasimpl ;
   autosubst_unfold ;

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -55,11 +55,6 @@ Inductive quoted_cterm :=
 | qren (r : quoted_ren) (t : quoted_cterm)
 | qsubst (s : quoted_subst) (t : quoted_cterm).
 
-(* Inductive quoted_goal : Type → Type :=
-| qcterm (t : quoted_cterm) : quoted_goal cterm
-| qapp {A B} (f : A → quoted_goal B) (a : quoted_goal A) : quoted_goal B
-| qgoal {A} (a : A) : quoted_goal A. *)
-
 Fixpoint unquote_ren q :=
   match q with
   | qren_atom ρ => ρ
@@ -83,13 +78,6 @@ Fixpoint unquote_cterm q :=
   | qren r t => ren_cterm (unquote_ren r) (unquote_cterm t)
   | qsubst s t => subst_cterm (unquote_subst s) (unquote_cterm t)
   end.
-
-(* Fixpoint unquote_goal {A} (q : quoted_goal A) : A :=
-  match q with
-  | qcterm t => unquote_cterm t
-  | qapp f a => unquote_goal (f (unquote_goal a))
-  | qgoal a => a
-  end. *)
 
 (** Evaluation **)
 
@@ -145,13 +133,6 @@ Fixpoint eval_cterm (t : quoted_cterm) : quoted_cterm :=
   | _ => t
   end.
 
-(* Fixpoint eval_goal {A} (q : quoted_goal A) : quoted_goal A :=
-  match q with
-  | qcterm t => qcterm (eval_cterm t)
-  | qapp f a => qapp (λ x, eval_goal (f x)) (eval_goal a)
-  | qgoal a => qgoal a
-  end. *)
-
 (** Correctness **)
 
 Lemma eval_ren_sound :
@@ -175,12 +156,6 @@ Lemma eval_cterm_sound :
     unquote_cterm t = unquote_cterm (eval_cterm t).
 Proof.
 Admitted.
-
-(* Lemma eval_goal_sound :
-  ∀ A (g : quoted_goal A),
-    unquote_goal g = unquote_goal (eval_goal g).
-Proof.
-Admitted. *)
 
 (** Quoting **)
 
@@ -233,21 +208,6 @@ Ltac quote_cterm t :=
   | _ => constr:(qatom t)
   end.
 
-(* Ltac quote_goal g :=
-  match g with
-  | ren1 _ _ =>
-    let q := quote_cterm g in
-    constr:(qcterm q)
-  | subst1 _ _ =>
-    let q := quote_cterm g in
-    constr:(qcterm q)
-  | ?f ?u =>
-    let qf := quote_goal f in
-    let qu := quote_goal u in
-    constr:(qapp qf qu)
-  | _ => constr:(qgoal g)
-  end. *)
-
 (** Main tactic **)
 
 Ltac rasimpl1 :=
@@ -263,3 +223,6 @@ Ltac rasimpl1 :=
       ren_cterm subst_cterm
     ]
   end.
+
+Ltac rasimpl :=
+  repeat rasimpl1.

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -603,6 +603,7 @@ Ltac quote_ren r :=
     let q := quote_ren r in
     constr:(qren_cons qn q)
   | id => constr:(qren_id)
+  | λ x, x => constr:(qren_id)
   | shift => constr:(qren_shift)
   | S => constr:(qren_shift)
   | _ => constr:(qren_atom r)

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -35,50 +35,23 @@ Ltac ssimpl :=
   asimpl ;
   repeat unfold_funcomp.
 
-(** Autosubst NbE tactic that should be more efficient than asimpl/ssimpl
-
-  We reproduce what asimpl' does first:
-  - Make sure each term only has at most one substitution ore renaming applied
-    to it, resorting to composition instead.
-  - Apply renamings and substitutions to variables.
-  - Get rid of identity renamings and substitutions.
-  - Calls fsimpl to simplify expressions.
-
-**)
-
-About substSubst_cterm_pointwise.
-About substSubst_cterm.
-About substRen_cterm_pointwise.
-About substRen_cterm.
-About renSubst_cterm_pointwise.
-About renSubst_cterm.
-About renRen'_cterm_pointwise.
-About renRen_cterm.
-About varLRen'_cterm_pointwise.
-About varLRen'_cterm.
-About varL'_cterm_pointwise.
-About varL'_cterm.
-About rinstId'_cterm_pointwise.
-About rinstId'_cterm.
-About instId'_cterm_pointwise.
-About instId'_cterm.
-
-Print up_cterm_cterm.
-Print upRen_cterm_cterm.
-Print up_ren.
-
-Print funcomp.
+(** Autosubst reflective tactic that should be more efficient than asimpl **)
 
 Inductive quoted_ren :=
 | qren_atom (ρ : nat → nat)
-| qren_comp (r q : quoted_ren).
+| qren_comp (r q : quoted_ren)
+| qren_cons (n : nat) (q : quoted_ren)
+| qren_id
+| qren_shift.
 
 Inductive quoted_subst :=
 | qsubst_atom (σ : nat → cterm)
-| qsubst_comp (s t : quoted_subst).
+| qsubst_comp (s t : quoted_subst)
+| qsubst_cons (t : cterm) (s : quoted_subst)
+| qsubst_id.
 
 Inductive quoted_cterm :=
-| qmeta (t : cterm)
+| qatom (t : cterm)
 | qren (r : quoted_ren) (t : quoted_cterm)
 | qsubst (s : quoted_subst) (t : quoted_cterm).
 
@@ -86,150 +59,145 @@ Fixpoint unquote_ren q :=
   match q with
   | qren_atom ρ => ρ
   | qren_comp r q => funcomp (unquote_ren r) (unquote_ren q)
+  | qren_cons n q => scons n (unquote_ren q)
+  | qren_id => id
+  | qren_shift => shift
   end.
 
 Fixpoint unquote_subst q :=
   match q with
   | qsubst_atom σ => σ
   | qsubst_comp s t => funcomp (subst_cterm (unquote_subst s)) (unquote_subst t)
+  | qsubst_cons t s => scons t (unquote_subst s)
+  | qsubst_id => ids
   end.
 
 Fixpoint unquote_cterm q :=
   match q with
-  | qmeta t => t
+  | qatom t => t
   | qren r t => ren1 (unquote_ren r) (unquote_cterm t)
   | qsubst s t => subst1 (unquote_subst s) (unquote_cterm t)
   end.
 
-(** A substitution/renaming is first a sequence of conses and then a composition
-    of atomic substitutions/renamings.
+(** Evaluation **)
 
-    TODO See where shifts end up.
-*)
-
-Definition normal_ren := (list nat * list (nat → nat))%type.
-
-Definition normal_subst := (list cterm * list (nat → cterm))%type.
-
-Definition normal_cterm := (normal_subst * cterm)%type.
-
-Fixpoint apply_ren (r : list (nat → nat)) n :=
+Fixpoint eval_ren (r : quoted_ren) :=
   match r with
-  | [] => n
-  | ρ :: r => ρ (apply_ren r n)
+  | qren_comp r q =>
+    let r := eval_ren r in
+    let q := eval_ren q in
+    match r, q with
+    | qren_id, _ => q
+    | _, qren_id => r
+    | qren_cons n r, qren_shift => r
+    | _, qren_comp u v => qren_comp (qren_comp r u) v
+    | _, qren_cons n q => qren_cons (unquote_ren r n) (qren_comp r q)
+    | _, _ => qren_comp r q
+    end
+  | qren_cons 0 qren_shift => qren_id
+  | _ => r
   end.
 
-Definition apply_nren (r : normal_ren) (n : nat) :=
-  let (l, r) := r in
-  match nth_error l n with
-  | Some x => x
-  | None => apply_ren r (n - length l)
+Fixpoint eval_subst (s : quoted_subst) : quoted_subst :=
+  match s with
+  | qsubst_comp u v =>
+    let u := eval_subst u in
+    let v := eval_subst v in
+    match u, v with
+    | qsubst_id, _ => v
+    | _, qsubst_id => u
+    | _, qsubst_comp x y => qsubst_comp (qsubst_comp u x) y
+    | _, qsubst_cons t s =>
+      qsubst_cons (subst1 (unquote_subst s) t) (qsubst_comp u s)
+    | _, _ => qsubst_comp u v
+    end
+  | _ => s
   end.
 
-Definition nr_comp (u v : normal_ren) :=
-  let '(ul, ur) := u in
-  let '(vl, vr) := v in
-
-
-Fixpoint nr_comp uc ur vc vr : normal_ren :=
-  match vc with
-  | [] => (uc, ur ++ vr)
-
-Fixpoint nr_comp (u v : normal_ren) :=
-  let (uc, ur) := u in
-  let (vc, vr) := v in
-
-
-Fixpoint ns_comp (u v : normal_subst) :=
-  match u with
-  | [] => v
-  |
-  end.
-
-Fixpoint eval_ren q :=
-  match q with
-  | qren_atom ρ => [ sren ρ ]
-  | qren_comp r q => eval_ren r ++ eval_ren q
-  end.
-
-Fixpoint eval_subst q :=
-  match q with
-  | qsubst_atom σ => [ ssubst σ ]
-  | qsubst_comp s t => eval_subst s ++ eval_subst t
-  end.
-
-Fixpoint eval_cterm q : normal_cterm :=
-  match q with
-  | qmeta t => ([], t)
+Fixpoint eval_cterm (t : quoted_cterm) : quoted_cterm :=
+  match t with
   | qren r t =>
-    let r' := eval_ren r in
-    let '(s',t') := eval_cterm t in
-    (s' ++ r', t')
+    let r := eval_ren r in
+    let t := eval_cterm t in
+    match t with
+    | qren r' t => qren (qren_comp r' r) t
+    | _ => qren r t
+    end
   | qsubst s t =>
-    let s' := eval_subst s in
-    let '(s'',t') := eval_cterm t in
-    (s'' ++ s', t')
-  end.
-
-Inductive normal_subst :=
-| nId
-| nRen (ρ : nat → nat)
-| nSubst (σ : nat → cterm).
-
-Definition ns_comp (s t : normal_subst) :=
-  match s, t with
-  | nId, _ => t
-  | _, nId => s
-  | nRen ρ, nRen ρ' => nRen (funcomp ρ ρ')
-  | nRen ρ, nSubst σ => nSubst (funcomp (ren_cterm ρ) σ)
-  | nSubst σ, nRen ρ => nSubst (funcomp σ ρ)
-  | nSubst σ, nSubst θ => nSubst (funcomp (subst_cterm σ) θ)
-  end.
-
-Definition nscons (t : cterm) s :=
-  match s with
-  | nId => nSubst (scons t cvar)
-  | nRen ρ => nSubst (scons t (funcomp cvar ρ))
-  | nSubst σ => nSubst (scons t σ)
-  end.
-
-(* TODO Instead of all this, have a better normal form than lists
-  of sparts. Like scons should be primitive in it.
-*)
-
-Fixpoint reify_sparts (s : list spart) : normal_subst :=
-  match s with
-  | [] => nId
-  | sren ρ :: s =>
-    match reify_sparts s with
-    | nId => nRen ρ
-    | nRen ρ' => nRen (funcomp ρ ρ')
-    | nSubst σ => nSubst (funcomp (ren_cterm ρ) σ)
+    let s := eval_subst s in
+    let t := eval_cterm t in
+    match t with
+    | qsubst s' t => qsubst (qsubst_comp s' s) t
+    | _ => qsubst s t
     end
-  | ssubst σ :: s =>
-    match reify_sparts s with
-    | nId => nSubst σ
-    | nRen ρ => nSubst (funcomp σ ρ)
-    | nSubst θ => nSubst (funcomp (subst_cterm σ) θ)
-    end
-  | sscons t k :: sshift :: s =>
-    let k' := reify_sparts k in
-    let s' := reify_sparts s in
-    ns_comp k' s'
-  | sscons t k :: s =>
-    let k' := reify_sparts k in
-    let s' := reify_sparts s in
-    ns_comp (nscons t k') s'
-  | sshift :: s =>
-    let s' := reify_sparts s in
-    ns_comp (nRen shift) s'
+  | _ => t
   end.
 
-Fixpoint reify_spart (s : list spart) (t : cterm) : cterm :=
-  match s with
-  | [] => t
-  | sren ρ ::
+(** Correctness **)
 
-Definition reify (t : normal_cterm) : cterm :=
-  let '(s,t) := t in
-  reify_spart s t.
+Lemma eval_ren_sound :
+  ∀ r n,
+    unquote_ren r n = unquote_ren (eval_ren r) n.
+Proof.
+  intros r n.
+  induction r in n |- *.
+  all: try reflexivity.
+  (* TODO Maybe funelim instead *)
+Admitted.
+
+Lemma eval_subst_sound :
+  ∀ s n,
+    unquote_subst s n = unquote_subst (eval_subst s) n.
+Proof.
+Admitted.
+
+Lemma eval_cterm_sound :
+  ∀ t,
+    unquote_cterm t = unquote_cterm (eval_cterm t).
+Proof.
+Admitted.
+
+(** Quoting **)
+
+Ltac quote_ren r :=
+  lazymatch r with
+  | funcomp ?r ?r' =>
+    let q := quote_ren r in
+    let q' := quote_ren r' in
+    constr:(qren_comp q q')
+  | scons ?n ?r =>
+    let q := quote_ren r in
+    constr:(qren_cons n q)
+  | id => constr:(qren_id)
+  | shift => constr:(qren_shift)
+  | S => constr:(qren_shift)
+  | _ => constr:(qren_atom r)
+  end.
+
+Ltac quote_subst s :=
+  lazymatch s with
+  | funcomp (subst_cterm ?s) ?t =>
+    let q := quote_subst s in
+    let q' := quote_subst t in
+    constr:(qsubst_comp q q')
+  | scons ?t ?s =>
+    let q := quote_subst s in
+    constr:(qsubst_cons t q)
+  | ids => constr:(qsubst_id)
+  | _ => constr:(qsubst_atom s)
+  end.
+
+Ltac quote_cterm t :=
+  lazymatch t with
+  | ren1 ?r ?t =>
+    let qr := quote_ren r in
+    let qt := quote_cterm t in
+    constr:(qren qr qt)
+  | subst1 ?s ?t =>
+    let qs := quote_subst s in
+    let qt := quote_cterm t in
+    constr:(qsubst qs qt)
+  | _ => constr:(qatom t)
+  end.
+
+(** Main tactic TODO **)

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -6,6 +6,7 @@
 
 From Coq Require Import Utf8 List.
 From GhostTT.autosubst Require Import core unscoped GAST CCAST.
+Import ListNotations.
 
 Notation "a ⋅ x" :=
   (ren1 a x) (at level 20, right associativity) : subst_scope.
@@ -33,3 +34,202 @@ Ltac ssimpl :=
   resubst ;
   asimpl ;
   repeat unfold_funcomp.
+
+(** Autosubst NbE tactic that should be more efficient than asimpl/ssimpl
+
+  We reproduce what asimpl' does first:
+  - Make sure each term only has at most one substitution ore renaming applied
+    to it, resorting to composition instead.
+  - Apply renamings and substitutions to variables.
+  - Get rid of identity renamings and substitutions.
+  - Calls fsimpl to simplify expressions.
+
+**)
+
+About substSubst_cterm_pointwise.
+About substSubst_cterm.
+About substRen_cterm_pointwise.
+About substRen_cterm.
+About renSubst_cterm_pointwise.
+About renSubst_cterm.
+About renRen'_cterm_pointwise.
+About renRen_cterm.
+About varLRen'_cterm_pointwise.
+About varLRen'_cterm.
+About varL'_cterm_pointwise.
+About varL'_cterm.
+About rinstId'_cterm_pointwise.
+About rinstId'_cterm.
+About instId'_cterm_pointwise.
+About instId'_cterm.
+
+Print up_cterm_cterm.
+Print upRen_cterm_cterm.
+Print up_ren.
+
+Print funcomp.
+
+Inductive quoted_ren :=
+| qren_atom (ρ : nat → nat)
+| qren_comp (r q : quoted_ren).
+
+Inductive quoted_subst :=
+| qsubst_atom (σ : nat → cterm)
+| qsubst_comp (s t : quoted_subst).
+
+Inductive quoted_cterm :=
+| qmeta (t : cterm)
+| qren (r : quoted_ren) (t : quoted_cterm)
+| qsubst (s : quoted_subst) (t : quoted_cterm).
+
+Fixpoint unquote_ren q :=
+  match q with
+  | qren_atom ρ => ρ
+  | qren_comp r q => funcomp (unquote_ren r) (unquote_ren q)
+  end.
+
+Fixpoint unquote_subst q :=
+  match q with
+  | qsubst_atom σ => σ
+  | qsubst_comp s t => funcomp (subst_cterm (unquote_subst s)) (unquote_subst t)
+  end.
+
+Fixpoint unquote_cterm q :=
+  match q with
+  | qmeta t => t
+  | qren r t => ren1 (unquote_ren r) (unquote_cterm t)
+  | qsubst s t => subst1 (unquote_subst s) (unquote_cterm t)
+  end.
+
+(** A substitution/renaming is first a sequence of conses and then a composition
+    of atomic substitutions/renamings.
+
+    TODO See where shifts end up.
+*)
+
+Definition normal_ren := (list nat * list (nat → nat))%type.
+
+Definition normal_subst := (list cterm * list (nat → cterm))%type.
+
+Definition normal_cterm := (normal_subst * cterm)%type.
+
+Fixpoint apply_ren (r : list (nat → nat)) n :=
+  match r with
+  | [] => n
+  | ρ :: r => ρ (apply_ren r n)
+  end.
+
+Definition apply_nren (r : normal_ren) (n : nat) :=
+  let (l, r) := r in
+  match nth_error l n with
+  | Some x => x
+  | None => apply_ren r (n - length l)
+  end.
+
+Definition nr_comp (u v : normal_ren) :=
+  let '(ul, ur) := u in
+  let '(vl, vr) := v in
+
+
+Fixpoint nr_comp uc ur vc vr : normal_ren :=
+  match vc with
+  | [] => (uc, ur ++ vr)
+
+Fixpoint nr_comp (u v : normal_ren) :=
+  let (uc, ur) := u in
+  let (vc, vr) := v in
+
+
+Fixpoint ns_comp (u v : normal_subst) :=
+  match u with
+  | [] => v
+  |
+  end.
+
+Fixpoint eval_ren q :=
+  match q with
+  | qren_atom ρ => [ sren ρ ]
+  | qren_comp r q => eval_ren r ++ eval_ren q
+  end.
+
+Fixpoint eval_subst q :=
+  match q with
+  | qsubst_atom σ => [ ssubst σ ]
+  | qsubst_comp s t => eval_subst s ++ eval_subst t
+  end.
+
+Fixpoint eval_cterm q : normal_cterm :=
+  match q with
+  | qmeta t => ([], t)
+  | qren r t =>
+    let r' := eval_ren r in
+    let '(s',t') := eval_cterm t in
+    (s' ++ r', t')
+  | qsubst s t =>
+    let s' := eval_subst s in
+    let '(s'',t') := eval_cterm t in
+    (s'' ++ s', t')
+  end.
+
+Inductive normal_subst :=
+| nId
+| nRen (ρ : nat → nat)
+| nSubst (σ : nat → cterm).
+
+Definition ns_comp (s t : normal_subst) :=
+  match s, t with
+  | nId, _ => t
+  | _, nId => s
+  | nRen ρ, nRen ρ' => nRen (funcomp ρ ρ')
+  | nRen ρ, nSubst σ => nSubst (funcomp (ren_cterm ρ) σ)
+  | nSubst σ, nRen ρ => nSubst (funcomp σ ρ)
+  | nSubst σ, nSubst θ => nSubst (funcomp (subst_cterm σ) θ)
+  end.
+
+Definition nscons (t : cterm) s :=
+  match s with
+  | nId => nSubst (scons t cvar)
+  | nRen ρ => nSubst (scons t (funcomp cvar ρ))
+  | nSubst σ => nSubst (scons t σ)
+  end.
+
+(* TODO Instead of all this, have a better normal form than lists
+  of sparts. Like scons should be primitive in it.
+*)
+
+Fixpoint reify_sparts (s : list spart) : normal_subst :=
+  match s with
+  | [] => nId
+  | sren ρ :: s =>
+    match reify_sparts s with
+    | nId => nRen ρ
+    | nRen ρ' => nRen (funcomp ρ ρ')
+    | nSubst σ => nSubst (funcomp (ren_cterm ρ) σ)
+    end
+  | ssubst σ :: s =>
+    match reify_sparts s with
+    | nId => nSubst σ
+    | nRen ρ => nSubst (funcomp σ ρ)
+    | nSubst θ => nSubst (funcomp (subst_cterm σ) θ)
+    end
+  | sscons t k :: sshift :: s =>
+    let k' := reify_sparts k in
+    let s' := reify_sparts s in
+    ns_comp k' s'
+  | sscons t k :: s =>
+    let k' := reify_sparts k in
+    let s' := reify_sparts s in
+    ns_comp (nscons t k') s'
+  | sshift :: s =>
+    let s' := reify_sparts s in
+    ns_comp (nRen shift) s'
+  end.
+
+Fixpoint reify_spart (s : list spart) (t : cterm) : cterm :=
+  match s with
+  | [] => t
+  | sren ρ ::
+
+Definition reify (t : normal_cterm) : cterm :=
+  let '(s,t) := t in
+  reify_spart s t.

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -173,6 +173,7 @@ Inductive eval_subst_comp_view : quoted_subst → quoted_subst → Type :=
 | es_compr_r s x y : eval_subst_comp_view s (qsubst_compr x y)
 | es_rcomp_r s x y : eval_subst_comp_view s (qsubst_rcomp x y)
 | es_cons_r s t s' : eval_subst_comp_view s (qsubst_cons t s')
+| es_ren_l r s : eval_subst_comp_view (qsubst_ren r) s
 | es_ren_r s r : eval_subst_comp_view s (qsubst_ren r)
 | es_other u v : eval_subst_comp_view u v.
 
@@ -184,6 +185,7 @@ Definition eval_subst_comp_c u v : eval_subst_comp_view u v :=
   | u, qsubst_compr x y => es_compr_r u x y
   | u, qsubst_rcomp x y => es_rcomp_r u x y
   | u, qsubst_cons t s => es_cons_r u t s
+  | qsubst_ren r, s => es_ren_l r s
   | u, qsubst_ren r => es_ren_r u r
   | u, v => es_other u v
   end.
@@ -252,6 +254,7 @@ Fixpoint eval_subst (s : quoted_subst) : quoted_subst :=
     | es_compr_r u x y => qsubst_compr (qsubst_comp u x) y
     | es_rcomp_r u x y => qsubst_comp (qsubst_compr u x) y
     | es_cons_r u t s => qsubst_cons (subst_cterm (unquote_subst u) t) (qsubst_comp u s)
+    | es_ren_l r s => qsubst_rcomp r s
     | es_ren_r u r => qsubst_compr u r
     | es_other u v => qsubst_comp u v
     end
@@ -451,6 +454,10 @@ Proof.
     + cbn in *. unfold funcomp.
       erewrite subst_cterm_morphism. 2,3: eauto.
       asimpl. destruct n. all: reflexivity.
+    + cbn in *. unfold funcomp in *.
+      rewrite IHs2.
+      rewrite rinstInst'_cterm. apply subst_cterm_morphism. 2: reflexivity.
+      intro. rewrite IHs1. unfold funcomp. reflexivity.
     + cbn in *. unfold funcomp in *.
       rewrite IHs2. cbn. rewrite IHs1. reflexivity.
     + cbn in *. unfold funcomp. rewrite IHs2.


### PR DESCRIPTION
This introduces some semi-reflective tactic `rasimpl` which proceeds by quoting the term and then performing rewriting on the quoted syntax rather than relying on `setoid_rewrite`.
The tactic seems to be much faster, but I'm sure there's a lot of room for improvement.

Sadly, it seems the gain is dwarfed by the time `Param` takes which might be due to the memory it takes. It is worth noting that I did not replace all uses of `asimpl` or `ssimpl` which are slow because I didn't want to have to reprove too much.