### PR TITLE
New implementation of `rasimpl` using `rewrite_start`

### DIFF
--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -634,62 +634,67 @@ Proof.
     + rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
-    (* If I replace by asimpl it works, the problem is that rasimpl is more
-      performant than asimpl in the goal than in the hypothesis for some reason.
-      In the hypothesis they yield exactly the same thing. I guess just cbn +
-      aunfold.
-     *)
-    rasimpl. eauto.
+    rasimpl. eapply cmeta_conv. 1: eauto.
+    rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     instantiate (1 := i). instantiate (1 := m).
-    rasimpl. eauto.
+    rasimpl. eapply cmeta_conv. 1: eauto.
+    rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5.
     eapply cmeta_conv. 1: econstructor. all: eauto.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4.
     eapply cmeta_conv. 1: econstructor. all: eauto.
-    rasimpl. eauto.
+    rasimpl. eapply cmeta_conv. 1: eauto.
+    rasimpl. f_equal. f_equal. f_equal. f_equal.
+    rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
     rasimpl in IHht8.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
       f_equal. f_equal. f_equal. f_equal. f_equal.
-      rasimpl. eapply ext_cterm.
-      intros [].
-      * rasimpl. reflexivity.
-      * rasimpl. reflexivity.
+      rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      clear. f_equal. rasimpl. reflexivity.
+      clear. f_equal. rasimpl. f_equal. all: f_equal. all: f_equal.
+      all: rasimpl. all: reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      clear. f_equal. f_equal. rasimpl. reflexivity.
+      clear. f_equal. f_equal. f_equal. all: f_equal. all: f_equal.
+      2-4: f_equal. 2-4: f_equal.
+      all: rasimpl. all: reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     eapply cmeta_conv. 1: eauto.
     clear. f_equal. f_equal.
-    rasimpl. reflexivity.
+    rasimpl. f_equal. all: f_equal. all: f_equal.
+    all: rasimpl. all: reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     eapply cmeta_conv. 1: eauto.
-    f_equal. rasimpl. reflexivity.
+    f_equal. rasimpl. f_equal. all: f_equal. all: f_equal.
+    2-3: f_equal.
+    all: rasimpl. all: reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
     rasimpl in IHht8. rasimpl in IHht9. rasimpl in IHht10. rasimpl in IHht11.
     rasimpl in IHht12.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. f_equal.
-      rasimpl. reflexivity.
+      clear. f_equal. f_equal. f_equal. all: f_equal. all: f_equal.
+      2-3: f_equal. 4: f_equal.
+      all: rasimpl. all: reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. rasimpl. reflexivity.
+      clear. f_equal. f_equal. all: f_equal. all: f_equal.
+      2-3: f_equal.
+      all: rasimpl. all: reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. rasimpl. f_equal. f_equal. f_equal. unfold capps. cbn. f_equal.
-      f_equal. f_equal. f_equal. all: f_equal. all: f_equal. all: f_equal.
-      all: f_equal. 1,2: f_equal.
+      clear. f_equal. f_equal. all: f_equal. 2: f_equal. 2: unfold capps.
+      2: cbn. 2: f_equal. 2-3: f_equal. 2-4: f_equal. 3-5: f_equal.
+      5-7: f_equal. 6-8: f_equal. 6-8: f_equal. 6-8: f_equal. 6-7: f_equal.
       all: rasimpl. all: reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
@@ -697,23 +702,35 @@ Proof.
     rasimpl in IHht12.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
-      clear. f_equal. f_equal.
-      rasimpl. reflexivity.
+      clear. f_equal. f_equal. f_equal. all: f_equal. all: f_equal.
+      2-3: f_equal. 4: f_equal.
+      all: rasimpl. all: reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      clear. f_equal. rasimpl. reflexivity.
+      clear. f_equal. f_equal. f_equal. all: f_equal. all: f_equal.
+      2-3: f_equal.
+      all: rasimpl. all: reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      clear. f_equal. rasimpl. unfold capps. cbn. rasimpl. reflexivity.
-    + clear. cbn. unfold elength. f_equal. f_equal. f_equal.
-      rasimpl. reflexivity.
+      clear. f_equal. unfold capps. cbn. f_equal. all: f_equal.
+      2: f_equal. 2: f_equal. 2-3: f_equal. 2-4: f_equal. 3-5: f_equal.
+      5-7: f_equal. 6-8: f_equal. 6-8: f_equal. 6-8: f_equal. 6-8: f_equal.
+      all: rasimpl. all: reflexivity.
+    + clear. cbn. unfold elength. f_equal. f_equal. f_equal. f_equal.
+      all: f_equal. all: f_equal. 2-3: f_equal. 3-4: f_equal. 3-5: f_equal.
+      3,5: f_equal. 4: f_equal.
+      all: rasimpl. all: reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
     rasimpl in IHht8. rasimpl in IHht9. rasimpl in IHht10.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
-      clear. f_equal. f_equal.
-      rasimpl. reflexivity.
+      clear. f_equal. f_equal. f_equal. all: f_equal. all: f_equal.
+      2: f_equal.
+      all: rasimpl. all: reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      clear. unfold capps. cbn. rasimpl. reflexivity.
+      clear. unfold capps. cbn. f_equal. f_equal.  all: f_equal.
+      2: f_equal. 2: f_equal. 2-3: f_equal. 2-4: f_equal. 3-5: f_equal.
+      5-6: f_equal. 5-6: f_equal. 5-6: f_equal.
+      all: rasimpl. all: reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2.
     econstructor. all: eauto.
     eapply cconv_subst. all: eassumption.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -140,6 +140,18 @@ Proof.
   intros n m en. rewrite <- e. apply h. assumption.
 Qed.
 
+Lemma autosubst_simpl_crscoping :
+  ∀ Γ Δ r s,
+    RenSimplification r s →
+    crscoping Γ r Δ ↔ crscoping Γ s Δ.
+Proof.
+  intros Γ Δ r s H.
+  apply crscoping_morphism. 1,3: auto.
+  apply H.
+Qed.
+
+#[export] Hint Rewrite -> autosubst_simpl_crscoping : asimpl_outermost.
+
 #[export] Instance csscoping_morphism :
   Proper (eq ==> pointwise_relation _ eq ==> eq ==> iff) csscoping.
 Proof.
@@ -151,6 +163,18 @@ Proof.
     + apply ih. intros n. apply e.
     + rewrite <- e. assumption.
 Qed.
+
+Lemma autosubst_simpl_csscoping :
+  ∀ Γ Δ r s,
+    CSubstSimplification r s →
+    csscoping Γ r Δ ↔ csscoping Γ s Δ.
+Proof.
+  intros Γ Δ r s H.
+  apply csscoping_morphism. 1,3: auto.
+  apply H.
+Qed.
+
+#[export] Hint Rewrite -> autosubst_simpl_csscoping : asimpl_outermost.
 
 Lemma csscoping_ids :
   ∀ Γ,
@@ -196,6 +220,18 @@ Proof.
   apply extRen_cterm. intro x. cbn. core.unfold_funcomp.
   rewrite <- e. reflexivity.
 Qed.
+
+Lemma autosubst_simpl_crtyping :
+  ∀ Γ Δ r s,
+    RenSimplification r s →
+    crtyping Γ r Δ ↔ crtyping Γ s Δ.
+Proof.
+  intros Γ Δ r s H.
+  apply crtyping_morphism. 1,3: auto.
+  apply H.
+Qed.
+
+#[export] Hint Rewrite -> autosubst_simpl_crtyping : asimpl_outermost.
 
 Lemma crtyping_cscoping :
   ∀ Γ Δ ρ,
@@ -365,9 +401,7 @@ Proof.
     + eapply cmeta_conv. 1: eauto.
       f_equal. rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. f_equal. rasimpl.
-      f_equal. all: f_equal. all: f_equal. 2-4: f_equal. 2-4: f_equal.
-      all: rasimpl. all: reflexivity.
+      f_equal. f_equal. rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6.
     eapply cmeta_conv. 1: econstructor. all: eauto.
@@ -394,12 +428,7 @@ Proof.
       all: rasimpl. all: reflexivity.
     + eapply cmeta_conv. 1: eauto.
       unfold capps. cbn.
-      f_equal. rasimpl. f_equal. all: f_equal.
-      1:{ rasimpl. reflexivity. }
-      f_equal. f_equal. all: f_equal. all: f_equal.
-      2-4: f_equal. 4-6: f_equal. 5-7: f_equal. 5-7: f_equal. 5-7: f_equal.
-      5-6: f_equal.
-      all: rasimpl. all: reflexivity.
+      f_equal. rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
     rasimpl in IHht8. rasimpl in IHht9. rasimpl in IHht10. rasimpl in IHht11.
@@ -413,12 +442,8 @@ Proof.
       f_equal. f_equal. f_equal. all: f_equal. all: f_equal. 2-3: f_equal.
       all: rasimpl. all: reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. rasimpl. f_equal. all: f_equal.
-      1:{ rasimpl. reflexivity. }
-      f_equal. unfold capps. cbn. f_equal. all: f_equal. all: f_equal.
-      2-4: f_equal. 4-6: f_equal. 5-7: f_equal. 5-7: f_equal. 5-7: f_equal.
-      5-7: f_equal.
-      all: rasimpl. all: reflexivity.
+      f_equal. rasimpl. f_equal. f_equal. f_equal. f_equal. f_equal.
+      unfold capps. cbn. rasimpl. reflexivity.
     + cbn. unfold elength. f_equal. f_equal. f_equal. f_equal. all: f_equal.
       all: f_equal. 2-3: f_equal. 3-4: f_equal. 3-5: f_equal. 3,5: f_equal.
       4: f_equal.
@@ -432,10 +457,7 @@ Proof.
       f_equal. f_equal. f_equal. all: f_equal. all: f_equal. 2: f_equal.
       all: rasimpl. all: reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. rasimpl. cbn. f_equal. all: f_equal. 2: f_equal. 2: f_equal.
-      2-3: f_equal. 2-4: f_equal. 3-5: f_equal. 5-6: f_equal. 5-6: f_equal.
-      5-6: f_equal.
-      all: rasimpl. all: reflexivity.
+      clear. cbn. rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2.
     econstructor. all: eauto.
     eapply cconv_ren. all: eassumption.
@@ -470,6 +492,18 @@ Proof.
         rasimpl. apply ext_cterm.
         intro. apply e.
 Qed.
+
+Lemma autosubst_simpl_cstyping :
+  ∀ Γ Δ r s,
+    CSubstSimplification r s →
+    cstyping Γ r Δ ↔ cstyping Γ s Δ.
+Proof.
+  intros Γ Δ r s H.
+  apply styping_morphism. 1,3: auto.
+  apply H.
+Qed.
+
+#[export] Hint Rewrite -> autosubst_simpl_cstyping : asimpl_outermost.
 
 Lemma cstyping_cscoping :
   ∀ Γ Δ σ,
@@ -674,9 +708,7 @@ Proof.
     rasimpl in IHht4. rasimpl in IHht5.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     eapply cmeta_conv. 1: eauto.
-    f_equal. rasimpl. f_equal. all: f_equal. all: f_equal.
-    2-3: f_equal.
-    all: rasimpl. all: reflexivity.
+    f_equal. rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
     rasimpl in IHht8. rasimpl in IHht9. rasimpl in IHht10. rasimpl in IHht11.
@@ -691,10 +723,7 @@ Proof.
       2-3: f_equal.
       all: rasimpl. all: reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      clear. f_equal. f_equal. all: f_equal. 2: f_equal. 2: unfold capps.
-      2: cbn. 2: f_equal. 2-3: f_equal. 2-4: f_equal. 3-5: f_equal.
-      5-7: f_equal. 6-8: f_equal. 6-8: f_equal. 6-8: f_equal. 6-7: f_equal.
-      all: rasimpl. all: reflexivity.
+      clear. unfold capps. cbn. rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
     rasimpl in IHht8. rasimpl in IHht9. rasimpl in IHht10. rasimpl in IHht11.
@@ -713,10 +742,7 @@ Proof.
       2: f_equal. 2: f_equal. 2-3: f_equal. 2-4: f_equal. 3-5: f_equal.
       5-7: f_equal. 6-8: f_equal. 6-8: f_equal. 6-8: f_equal. 6-8: f_equal.
       all: rasimpl. all: reflexivity.
-    + clear. cbn. unfold elength. f_equal. f_equal. f_equal. f_equal.
-      all: f_equal. all: f_equal. 2-3: f_equal. 3-4: f_equal. 3-5: f_equal.
-      3,5: f_equal. 4: f_equal.
-      all: rasimpl. all: reflexivity.
+    + clear. cbn. unfold elength. rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
     rasimpl in IHht8. rasimpl in IHht9. rasimpl in IHht10.
@@ -726,10 +752,7 @@ Proof.
       2: f_equal.
       all: rasimpl. all: reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      clear. unfold capps. cbn. f_equal. f_equal.  all: f_equal.
-      2: f_equal. 2: f_equal. 2-3: f_equal. 2-4: f_equal. 3-5: f_equal.
-      5-6: f_equal. 5-6: f_equal. 5-6: f_equal.
-      all: rasimpl. all: reflexivity.
+      clear. unfold capps. cbn. rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2.
     econstructor. all: eauto.
     eapply cconv_subst. all: eassumption.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -221,15 +221,6 @@ Proof.
   destruct y.
   - cbn in *. noconf hy. eexists.
     split. 1: reflexivity.
-    aunfold.
-    core.minimize.
-    rewrite_strat (subterms autosubst_simpl_cterm).
-    2,3: exact _.
-    post_process.
-    (* Almost there, but why isn't type class resolution called?
-      Is it a hint mode thing?
-    *)
-    fail.
     rasimpl. reflexivity.
   - cbn in *. eapply hρ in hy. destruct hy as [C [en eC]].
     eexists. split. 1: eassumption.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -313,10 +313,7 @@ Proof.
   induction h in Γ, ρ, hρ |- *.
   all: try solve [ rasimpl ; econstructor ; eauto ; cscoping_ren_finish ].
   - rasimpl. eapply cmeta_conv_trans_r. 1: econstructor.
-    rasimpl.
-    rewrite_strat (topdown (progress (hints asimpl))).
-    fail.
-    reflexivity.
+    rasimpl. reflexivity.
   - rasimpl. constructor.
     + auto.
     + eapply IHh2. apply crtyping_shift. assumption.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -211,6 +211,14 @@ Proof.
   rewrite en. reflexivity.
 Qed.
 
+#[export] Instance ASimplification_cterm t {q} :
+  CTermQuote t q →
+  ASimplification t (unquote_cterm (eval_cterm q)).
+Proof.
+  intros [->].
+  constructor. apply eval_cterm_sound.
+Qed.
+
 Lemma crtyping_shift :
   ∀ Γ Δ mx A ρ,
     crtyping Γ ρ Δ →
@@ -221,6 +229,10 @@ Proof.
   destruct y.
   - cbn in *. noconf hy. eexists.
     split. 1: reflexivity.
+    (* rewrite autosubst_simpl. *)
+    lazymatch goal with
+    | |- _ = ?t => rewrite (autosubst_simpl t)
+    end.
     rasimpl. reflexivity.
   - cbn in *. eapply hρ in hy. destruct hy as [C [en eC]].
     eexists. split. 1: eassumption.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -211,13 +211,14 @@ Proof.
   rewrite en. reflexivity.
 Qed.
 
-#[export] Instance ASimplification_cterm t {q} :
-  CTermQuote t q →
-  ASimplification t (unquote_cterm (eval_cterm q)).
+(* Instance subrelation_eq_iff : subrelation eq (Basics.flip Basics.impl).
 Proof.
-  intros [->].
-  constructor. apply eval_cterm_sound.
-Qed.
+  destruct 1. reflexivity.
+Qed. *)
+
+(* TODO Maybe specialise to cterm but then we lose generality?
+  Maybe that's ok, we don't really have it anyway.
+*)
 
 Lemma crtyping_shift :
   ∀ Γ Δ mx A ρ,
@@ -229,7 +230,8 @@ Proof.
   destruct y.
   - cbn in *. noconf hy. eexists.
     split. 1: reflexivity.
-    (* rewrite autosubst_simpl. *)
+    (* rewrite_strat (autosubst_simpl). *)
+    (* setoid_rewrite autosubst_simpl. *)
     lazymatch goal with
     | |- _ = ?t => rewrite (autosubst_simpl t)
     end.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -341,21 +341,10 @@ Proof.
   - rasimpl. rasimpl in IHht1.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     rasimpl. reflexivity.
-  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. asimpl in IHht3.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
-    rasimpl.
-
-    (* The problem here is that the subterms are never reached.
-      Because of how setoid rewrite replaces any term with an evar, there is no
-      way to overcome this without changing how simplification works.
-      Maybe by changing quoting and or eval.
-      Another option would be to tell setoid_rewrite to only focus on subterms
-      of the form ren1 _ _ or subst1 _ _.
-      That should actually be cheaper, but is that easy?
-    *)
-
-    eauto.
-  - rasimpl. rasimpl in IHht1. asimpl in IHht2. rasimpl in IHht3.
+    rasimpl. eauto.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     instantiate (1 := i). instantiate (1 := m).
     rasimpl. eauto.
@@ -363,12 +352,12 @@ Proof.
     rasimpl in IHht4. rasimpl in IHht5.
     eapply cmeta_conv. 1: econstructor. all: eauto.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
-    asimpl in IHht4.
+    rasimpl in IHht4.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     rasimpl. eauto.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
-    asimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. asimpl in IHht7.
-    asimpl in IHht8.
+    rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
+    rasimpl in IHht8.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
       f_equal. f_equal. f_equal. f_equal. f_equal.
@@ -376,32 +365,40 @@ Proof.
     + eapply cmeta_conv. 1: eauto.
       f_equal. rasimpl. reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. f_equal. rasimpl. reflexivity.
+      f_equal. f_equal. rasimpl.
+      f_equal. all: f_equal. all: f_equal. 2-4: f_equal. 2-4: f_equal.
+      all: rasimpl. all: reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     eapply cmeta_conv. 1: eauto.
-    f_equal. f_equal.
-    rasimpl. reflexivity.
+    f_equal. f_equal. f_equal. all: f_equal. all: f_equal.
+    all: rasimpl. all: reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     eapply cmeta_conv. 1: eauto.
-    f_equal. rasimpl. reflexivity.
+    f_equal. f_equal. all: f_equal. all: f_equal. 2,3: f_equal.
+    all: rasimpl. all: reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
     rasimpl in IHht8. rasimpl in IHht9. rasimpl in IHht10. rasimpl in IHht11.
     rasimpl in IHht12.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. f_equal.
-      rasimpl. reflexivity.
+      f_equal. f_equal. f_equal. all: f_equal. all: f_equal. 2,3: f_equal.
+      4: f_equal.
+      all: rasimpl. all: reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. rasimpl. reflexivity.
+      f_equal. f_equal. all: f_equal. all: f_equal. 2,3: f_equal.
+      all: rasimpl. all: reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. rasimpl. f_equal. f_equal. f_equal. f_equal. f_equal.
-      f_equal. unfold capps. cbn. f_equal. all: f_equal.
-      all: f_equal. all: f_equal. all: f_equal. 1,2: f_equal.
+      unfold capps. cbn.
+      f_equal. rasimpl. f_equal. all: f_equal.
+      1:{ rasimpl. reflexivity. }
+      f_equal. f_equal. all: f_equal. all: f_equal.
+      2-4: f_equal. 4-6: f_equal. 5-7: f_equal. 5-7: f_equal. 5-7: f_equal.
+      5-6: f_equal.
       all: rasimpl. all: reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
@@ -409,28 +406,35 @@ Proof.
     rasimpl in IHht12.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. f_equal.
-      rasimpl. reflexivity.
-    + eapply cmeta_conv. 1: eauto.
-      f_equal. rasimpl. reflexivity.
-    + eapply cmeta_conv. 1: eauto.
-      f_equal. rasimpl. f_equal. f_equal. f_equal. f_equal. f_equal.
-      f_equal. unfold capps. cbn. f_equal. all: f_equal.
-      all: f_equal. all: f_equal. all: f_equal. 1,2: f_equal.
+      f_equal. f_equal. f_equal. all: f_equal. all: f_equal. all: f_equal.
+      4: f_equal.
       all: rasimpl. all: reflexivity.
-    + cbn. unfold elength. f_equal. f_equal. f_equal. rasimpl.
-      reflexivity.
+    + eapply cmeta_conv. 1: eauto.
+      f_equal. f_equal. f_equal. all: f_equal. all: f_equal. 2-3: f_equal.
+      all: rasimpl. all: reflexivity.
+    + eapply cmeta_conv. 1: eauto.
+      f_equal. rasimpl. f_equal. all: f_equal.
+      1:{ rasimpl. reflexivity. }
+      f_equal. unfold capps. cbn. f_equal. all: f_equal. all: f_equal.
+      2-4: f_equal. 4-6: f_equal. 5-7: f_equal. 5-7: f_equal. 5-7: f_equal.
+      5-7: f_equal.
+      all: rasimpl. all: reflexivity.
+    + cbn. unfold elength. f_equal. f_equal. f_equal. f_equal. all: f_equal.
+      all: f_equal. 2-3: f_equal. 3-4: f_equal. 3-5: f_equal. 3,5: f_equal.
+      4: f_equal.
+      all: rasimpl.
+      all: reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
     rasimpl in IHht8. rasimpl in IHht9. rasimpl in IHht10.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. f_equal.
-      rasimpl. reflexivity.
+      f_equal. f_equal. f_equal. all: f_equal. all: f_equal. 2: f_equal.
+      all: rasimpl. all: reflexivity.
     + eapply cmeta_conv. 1: eauto.
-      f_equal. rasimpl. f_equal. f_equal. f_equal. f_equal.
-      f_equal. cbn. f_equal.
-      all: f_equal. all: f_equal. all: f_equal. all: f_equal.
+      f_equal. rasimpl. cbn. f_equal. all: f_equal. 2: f_equal. 2: f_equal.
+      2-3: f_equal. 2-4: f_equal. 3-5: f_equal. 5-6: f_equal. 5-6: f_equal.
+      5-6: f_equal.
       all: rasimpl. all: reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2.
     econstructor. all: eauto.
@@ -573,7 +577,7 @@ Lemma cstyping_one :
     cstyping Γ u.. (Some (mx, A) :: Γ).
 Proof.
   intros Γ mx A u h hm.
-  constructor. all: asimpl.
+  constructor. all: rasimpl.
   - apply cstyping_ids.
   - cbn. intuition auto. rasimpl. assumption.
 Qed.
@@ -628,10 +632,15 @@ Proof.
     rasimpl. apply ext_cterm. intros [].
     + rasimpl. reflexivity.
     + rasimpl. reflexivity.
-  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. asimpl in IHht3.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
+    (* If I replace by asimpl it works, the problem is that rasimpl is more
+      performant than asimpl in the goal than in the hypothesis for some reason.
+      In the hypothesis they yield exactly the same thing. I guess just cbn +
+      aunfold.
+     *)
     rasimpl. eauto.
-  - rasimpl. rasimpl in IHht1. asimpl in IHht2. rasimpl in IHht3.
+  - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     instantiate (1 := i). instantiate (1 := m).
     rasimpl. eauto.
@@ -639,9 +648,9 @@ Proof.
     rasimpl in IHht4. rasimpl in IHht5.
     eapply cmeta_conv. 1: econstructor. all: eauto.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
-    asimpl in IHht4.
+    rasimpl in IHht4.
     eapply cmeta_conv. 1: econstructor. all: eauto.
-    asimpl. eauto.
+    rasimpl. eauto.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.
     rasimpl in IHht8.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -343,7 +343,18 @@ Proof.
     rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. asimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
-    rasimpl. eauto.
+    rasimpl.
+
+    (* The problem here is that the subterms are never reached.
+      Because of how setoid rewrite replaces any term with an evar, there is no
+      way to overcome this without changing how simplification works.
+      Maybe by changing quoting and or eval.
+      Another option would be to tell setoid_rewrite to only focus on subterms
+      of the form ren1 _ _ or subst1 _ _.
+      That should actually be cheaper, but is that easy?
+    *)
+
+    eauto.
   - rasimpl. rasimpl in IHht1. asimpl in IHht2. rasimpl in IHht3.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     instantiate (1 := i). instantiate (1 := m).

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -648,7 +648,6 @@ Proof.
     rasimpl in IHht4.
     eapply cmeta_conv. 1: econstructor. all: eauto.
     rasimpl. eapply cmeta_conv. 1: eauto.
-    rasimpl. f_equal. f_equal. f_equal. f_equal.
     rasimpl. reflexivity.
   - rasimpl. rasimpl in IHht1. rasimpl in IHht2. rasimpl in IHht3.
     rasimpl in IHht4. rasimpl in IHht5. rasimpl in IHht6. rasimpl in IHht7.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -211,15 +211,6 @@ Proof.
   rewrite en. reflexivity.
 Qed.
 
-(* Instance subrelation_eq_iff : subrelation eq (Basics.flip Basics.impl).
-Proof.
-  destruct 1. reflexivity.
-Qed. *)
-
-(* TODO Maybe specialise to cterm but then we lose generality?
-  Maybe that's ok, we don't really have it anyway.
-*)
-
 Lemma crtyping_shift :
   ∀ Γ Δ mx A ρ,
     crtyping Γ ρ Δ →
@@ -230,11 +221,15 @@ Proof.
   destruct y.
   - cbn in *. noconf hy. eexists.
     split. 1: reflexivity.
-    (* rewrite_strat (autosubst_simpl). *)
-    (* setoid_rewrite autosubst_simpl. *)
-    lazymatch goal with
-    | |- _ = ?t => rewrite (autosubst_simpl t)
-    end.
+    aunfold.
+    core.minimize.
+    rewrite_strat (subterms autosubst_simpl_cterm).
+    2,3: exact _.
+    post_process.
+    (* Almost there, but why isn't type class resolution called?
+      Is it a hint mode thing?
+    *)
+    fail.
     rasimpl. reflexivity.
   - cbn in *. eapply hρ in hy. destruct hy as [C [en eC]].
     eexists. split. 1: eassumption.

--- a/theories/CCMetaTheory.v
+++ b/theories/CCMetaTheory.v
@@ -313,7 +313,10 @@ Proof.
   induction h in Γ, ρ, hρ |- *.
   all: try solve [ rasimpl ; econstructor ; eauto ; cscoping_ren_finish ].
   - rasimpl. eapply cmeta_conv_trans_r. 1: econstructor.
-    rasimpl. reflexivity.
+    rasimpl.
+    rewrite_strat (topdown (progress (hints asimpl))).
+    fail.
+    reflexivity.
   - rasimpl. constructor.
     + auto.
     + eapply IHh2. apply crtyping_shift. assumption.

--- a/theories/Erasure.v
+++ b/theories/Erasure.v
@@ -459,7 +459,7 @@ Proof.
       erewrite IHt2.
       2:{ eapply sscoping_shift. eassumption. }
       2:{ eapply sscoping_comp_shift. assumption. }
-      rasimpl. f_equal.
+      rasimpl. cbn. f_equal.
       eapply ext_cterm. intros [].
       * cbn. rewrite e0. reflexivity.
       * cbn. ssimpl.
@@ -767,6 +767,7 @@ Proof.
   - eassumption.
   - eapply (f_equal (λ A, ρ ⋅ A)) in eB.
     rasimpl in eB. rasimpl in eC.
+    rasimpl.
     rewrite eB. assumption.
 Qed.
 

--- a/theories/Param.v
+++ b/theories/Param.v
@@ -1664,7 +1664,27 @@ Proof.
     + unfold pcastTG. cbn. rasimpl.
 
         aunfold. minimize.
-        rewrite_strat (topdown (hints asimpl)). 2-61: try (exact _).
+
+        rewrite_strat (topdown (hints asimpl)).
+        (* Goal 54 is already instantiated!
+
+          So there is no way to solve it after the fact. But where is it coming
+          from??
+
+          I can test in the 1st goal to see where it appears by using f_equal
+          and the presence check.
+
+        *)
+        1:{
+          f_equal. f_equal. f_equal. f_equal. f_equal. f_equal. f_equal.
+          f_equal. f_equal. f_equal.
+          match goal with
+          | |- context [ PeanoNat.Nat.ones ] => idtac
+          end.
+        }
+
+        2-61: try (exact _).
+        Search PeanoNat.Nat.ones.
         (** TODO
           How do we solve this issue? If the rhs gets instantiated before
           it is solved we run into a problem. This comes from the fact that
@@ -1675,6 +1695,9 @@ Proof.
           that would break other things.
           Although I expect most times there shouldn't be overlap between
           evars, so why is this happening here?
+
+          Maybe we should only rewrite ren and substs with triggers like for
+          terms? That might also save some time?
         **)
 
 

--- a/theories/Param.v
+++ b/theories/Param.v
@@ -420,7 +420,7 @@ Proof.
   eexists. split.
   - eassumption.
   - rasimpl. unfold vreg. cbn. rasimpl. eapply extRen_cterm.
-    intro. ssimpl. unfold shift. lia.
+    intro. unfold funcomp, shift. lia.
 Qed.
 
 (** ⟦ Γ ⟧ε is a sub-context of ⟦ Γ ⟧p **)
@@ -795,7 +795,7 @@ Lemma pren_comp_S :
   ∀ ρ n, pren (ρ >> S) n = S (S (pren ρ n)).
 Proof.
   intros ρ n.
-  unfold pren. ssimpl. lia.
+  unfold pren. unfold funcomp. lia.
 Qed.
 
 Lemma pren_id :
@@ -819,7 +819,7 @@ Proof.
   intros ρ t.
   unfold epm_lift. rasimpl.
   eapply extRen_cterm. intro x.
-  unfold vreg, pren. ssimpl.
+  unfold vreg, pren. unfold funcomp.
   replace (x * 2) with (2 * x) by lia.
   rewrite PeanoNat.Nat.div2_succ_double.
   rewrite PeanoNat.Nat.odd_succ.
@@ -900,42 +900,10 @@ Proof.
         rewrite pren_epm_lift. cbn. f_equal.
         unfold close. ssimpl. reflexivity.
       }
-      1:{ ssimpl. reflexivity. }
-      f_equal.
-      ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-      ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
-    + f_equal. all: f_equal.
-      1:{ rewrite pren_epm_lift. cbn. reflexivity. }
-      1:{ cEl_ren. rewrite <- pren_epm_lift. rasimpl. reflexivity. }
-      f_equal. all: f_equal.
-      * rasimpl. reflexivity.
-      * rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
-    + f_equal. all: f_equal.
-      1:{ rewrite pren_epm_lift. cbn. reflexivity. }
-      1:{ cEl_ren. rewrite <- pren_epm_lift. rasimpl. reflexivity. }
-      f_equal. all: f_equal.
-      * rasimpl. reflexivity.
-      * rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
-    + f_equal. all: f_equal.
-      1:{
-        rewrite pren_epm_lift. cbn. f_equal.
-        unfold close. ssimpl. reflexivity.
-      }
-      1:{ cEl_ren. rewrite <- pren_epm_lift. ssimpl. reflexivity. }
-      f_equal. all: f_equal.
-      * rasimpl. reflexivity.
-      * rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
-    + f_equal. all: f_equal.
-      1:{
-        rewrite pren_epm_lift. cbn. f_equal.
-        unfold close. ssimpl. reflexivity.
-      }
       1:{ rasimpl. reflexivity. }
       f_equal.
-      ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+      unfold close. rasimpl. eapply ext_cterm.
+      intros [| []]. all: cbn. 1,2: reflexivity.
       ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
     + f_equal. all: f_equal.
       1:{ rewrite pren_epm_lift. cbn. reflexivity. }
@@ -968,23 +936,58 @@ Proof.
       }
       1:{ rasimpl. reflexivity. }
       f_equal.
-      ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+      unfold close. rasimpl. eapply ext_cterm.
+      intros [| []]. all: cbn. 1,2: reflexivity.
+      ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
+    + f_equal. all: f_equal.
+      1:{ rewrite pren_epm_lift. cbn. reflexivity. }
+      1:{ cEl_ren. rewrite <- pren_epm_lift. rasimpl. reflexivity. }
+      f_equal. all: f_equal.
+      * rasimpl. reflexivity.
+      * rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+        ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
+    + f_equal. all: f_equal.
+      1:{ rewrite pren_epm_lift. cbn. reflexivity. }
+      1:{ cEl_ren. rewrite <- pren_epm_lift. rasimpl. reflexivity. }
+      f_equal. all: f_equal.
+      * rasimpl. reflexivity.
+      * rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+        ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
+    + f_equal. all: f_equal.
+      1:{
+        rewrite pren_epm_lift. cbn. f_equal.
+        unfold close. ssimpl. reflexivity.
+      }
+      1:{ cEl_ren. rewrite <- pren_epm_lift. rasimpl. reflexivity. }
+      f_equal. all: f_equal.
+      * rasimpl. reflexivity.
+      * rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+        ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
+    + f_equal. all: f_equal.
+      1:{
+        rewrite pren_epm_lift. cbn. f_equal.
+        unfold close. ssimpl. reflexivity.
+      }
+      1:{ rasimpl. reflexivity. }
+      f_equal.
+      unfold close. rasimpl. eapply ext_cterm.
+      intros [| []]. all: cbn. 1,2: reflexivity.
       ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
     + f_equal. all: f_equal.
       1:{ rewrite pren_epm_lift. cbn. reflexivity. }
       1:{ rasimpl. reflexivity. }
       rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-      ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
+      rewrite pren_SS. unfold funcomp. rewrite <- pren_comp_S. reflexivity.
     + f_equal. all: f_equal.
       1:{ rewrite pren_epm_lift. reflexivity. }
       1:{ rasimpl. reflexivity. }
       rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-      ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. reflexivity.
+      rewrite pren_SS. unfold funcomp. rewrite <- pren_comp_S. reflexivity.
     + f_equal. all: f_equal.
       1:{ rewrite pren_epm_lift. reflexivity. }
       1:{ rasimpl. reflexivity. }
       rasimpl. eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-      ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. reflexivity.
+      rewrite pren_SS. unfold funcomp. rewrite <- pren_comp_S. reflexivity.
     + f_equal. unfold close. rasimpl.
       eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
       ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
@@ -1001,10 +1004,10 @@ Proof.
       ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. cbn. reflexivity.
     + cbn. rewrite pren_epm_lift. rasimpl. f_equal. f_equal.
       eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-      ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. reflexivity.
+      rewrite pren_SS. unfold funcomp. rewrite <- pren_comp_S. reflexivity.
     + cbn. rewrite pren_epm_lift. rasimpl. f_equal. f_equal.
       eapply extRen_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-      ssimpl. rewrite pren_SS. ssimpl. rewrite pren_comp_S. reflexivity.
+      rewrite pren_SS. unfold funcomp. rewrite <- pren_comp_S. reflexivity.
   - cbn.
     erewrite md_ren. 2,3: eassumption.
     erewrite IHt1. 2,3: eassumption.
@@ -1250,33 +1253,33 @@ Proof.
   rewrite PeanoNat.Nat.odd_succ.
   rewrite PeanoNat.Nat.even_succ.
   destruct_ifs. all: mode_eqs.
-  - ssimpl. erewrite erase_ren.
+  - unfold_funcomp. erewrite erase_ren.
     2: eapply rscoping_S.
     2: eapply rscoping_comp_S.
     rasimpl. rewrite <- pren_epm_lift.
     rasimpl. eapply extRen_cterm.
     intro x. unfold shift. change (pren S) with (pren (id >> S)).
     rewrite pren_comp_S. rasimpl. rewrite pren_id. reflexivity.
-  - ssimpl. erewrite param_ren.
+  - unfold_funcomp. erewrite param_ren.
     2: eapply rscoping_S.
     2: eapply rscoping_comp_S.
     rasimpl. eapply extRen_cterm.
     intro x. unfold shift. change (pren S) with (pren (id >> S)).
     rewrite pren_comp_S. rasimpl. rewrite pren_id. reflexivity.
-  - ssimpl. erewrite revive_ren.
+  - unfold_funcomp. erewrite revive_ren.
     2: eapply rscoping_S.
     2: eapply rscoping_comp_S.
     rasimpl. rewrite <- pren_rpm_lift.
     eapply extRen_cterm.
     intro x. unfold shift. change (pren S) with (pren (id >> S)).
     rewrite pren_comp_S. rasimpl. rewrite pren_id. reflexivity.
-  - ssimpl. erewrite param_ren.
+  - unfold_funcomp. erewrite param_ren.
     2: eapply rscoping_S.
     2: eapply rscoping_comp_S.
     rasimpl. eapply extRen_cterm.
     intro x. unfold shift. change (pren S) with (pren (id >> S)).
     rewrite pren_comp_S. rasimpl. rewrite pren_id. reflexivity.
-  - ssimpl. erewrite param_ren.
+  - unfold_funcomp. erewrite param_ren.
     2: eapply rscoping_S.
     2: eapply rscoping_comp_S.
     rasimpl. eapply extRen_cterm.
@@ -1293,10 +1296,11 @@ Lemma psubst_epm_lift :
     (epm_lift t) <[ psubst Δ Γ σ ] = epm_lift (t <[ σ >> erase_term Γ ]).
 Proof.
   intros Γ Δ σ t ht.
-  unfold epm_lift. ssimpl.
+  unfold epm_lift. rasimpl.
+  rewrite renSubst_cterm, substRen_cterm.
   eapply ext_cterm_scoped. 1: eassumption.
   intros x hx.
-  ssimpl. unfold psubst. rewrite div2_vreg.
+  unfold funcomp. unfold psubst. rewrite div2_vreg.
   unfold inscope in hx. unfold erase_sc in hx.
   rewrite nth_error_map in hx.
   destruct (nth_error Δ x) eqn:e. 2: discriminate.
@@ -1313,7 +1317,7 @@ Proof.
   unfold rpm_lift. rasimpl.
   eapply ext_cterm_scoped. 1: eassumption.
   intros x hx.
-  ssimpl. unfold psubst. rewrite div2_vreg.
+  unfold funcomp. unfold psubst. rewrite div2_vreg.
   unfold rev_subst. unfold ghv.
   unfold inscope in hx. unfold revive_sc in hx.
   rewrite nth_error_map in hx.
@@ -1365,12 +1369,12 @@ Proof.
       2:{ rasimpl. reflexivity. }
       2:{
         rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. rasimpl. reflexivity.
+        unfold funcomp. rewrite psubst_SS. rasimpl. reflexivity.
       }
       f_equal. all: f_equal. all: f_equal.
       all: eapply ext_cterm. all: rasimpl. all: intros [].
       all: cbn. 1,3: reflexivity.
-      all: ssimpl.
+      all: unfold funcomp.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
     + f_equal. all: f_equal.
       2:{ rasimpl. reflexivity. }
@@ -1380,12 +1384,12 @@ Proof.
       2:{ rasimpl. reflexivity. }
       2:{
         rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. rasimpl. reflexivity.
+        unfold funcomp. rewrite psubst_SS. rasimpl. reflexivity.
       }
       f_equal. all: f_equal. all: f_equal.
       all: eapply ext_cterm. all: rasimpl. all: intros [].
       all: cbn. 1,3: reflexivity.
-      all: ssimpl.
+      all: unfold funcomp.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
     + f_equal. all: f_equal.
       2:{ rasimpl. reflexivity. }
@@ -1395,13 +1399,14 @@ Proof.
       2:{ rasimpl. reflexivity. }
       2:{
         rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. rasimpl. reflexivity.
+        unfold funcomp. rewrite psubst_SS. rasimpl. reflexivity.
       }
       unfold cty_lift. f_equal. all: f_equal.
-      all: unfold close. all: ssimpl.
+      all: unfold close. all: rasimpl.
+      all: rewrite !substSubst_cterm.
       all: eapply ext_cterm. all: intros [].
       all: cbn. 1,3: reflexivity.
-      all: ssimpl.
+      all: unfold funcomp.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
       all: rasimpl. all: reflexivity.
     + f_equal. all: f_equal.
@@ -1410,15 +1415,17 @@ Proof.
       2:{ unshelve typeclasses eauto with cc_scope shelvedb. all: reflexivity. }
       all: f_equal.
       2:{
-        ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. rasimpl.
+        unfold close. rasimpl. eapply ext_cterm.
+        intros [| []]. all: cbn. 1,2: reflexivity.
+        unfold funcomp. rewrite psubst_SS. rasimpl.
         rewrite rinstInst'_cterm. reflexivity.
       }
       cbn. unfold cty_lift. f_equal. f_equal. all: f_equal.
-      all: unfold close. all: ssimpl.
+      all: unfold close. all: rasimpl.
+      all: rewrite !substSubst_cterm.
       all: eapply ext_cterm. all: intros [].
       all: cbn. 1,3: reflexivity.
-      all: ssimpl.
+      all: unfold funcomp.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
       all: rasimpl. all: reflexivity.
     + f_equal. all: f_equal.
@@ -1429,13 +1436,13 @@ Proof.
       2:{ rasimpl. reflexivity. }
       2:{
         rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. rasimpl. reflexivity.
+        unfold funcomp. rewrite psubst_SS. rasimpl. reflexivity.
       }
       cbn. f_equal. f_equal. all: f_equal. all: f_equal.
       all: rasimpl.
       all: eapply ext_cterm. all: intros [].
       all: cbn. 1,3: reflexivity.
-      all: ssimpl.
+      all: unfold funcomp.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
     + f_equal. all: f_equal.
       2:{ rasimpl. reflexivity. }
@@ -1445,13 +1452,13 @@ Proof.
       2:{ rasimpl. reflexivity. }
       2:{
         rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. rasimpl. reflexivity.
+        unfold funcomp. rewrite psubst_SS. rasimpl. reflexivity.
       }
       cbn. f_equal. f_equal. all: f_equal. all: f_equal.
       all: rasimpl.
       all: eapply ext_cterm. all: intros [].
       all: cbn. 1,3: reflexivity.
-      all: ssimpl.
+      all: unfold funcomp.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
     + f_equal. all: f_equal.
       2:{ rasimpl. reflexivity. }
@@ -1461,13 +1468,14 @@ Proof.
       2:{ rasimpl. reflexivity. }
       2:{
         rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
+        unfold funcomp. rewrite psubst_SS. rasimpl. reflexivity.
       }
       cbn. unfold cty_lift. f_equal. f_equal. all: f_equal. all: unfold close.
-      all: ssimpl.
+      all: rasimpl.
+      all: rewrite !substSubst_cterm.
       all: eapply ext_cterm. all: intros [].
       all: cbn. 1,3: reflexivity.
-      all: ssimpl.
+      all: unfold funcomp.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
       all: rasimpl. all: reflexivity.
     + f_equal. all: f_equal.
@@ -1476,15 +1484,16 @@ Proof.
       2:{ unshelve typeclasses eauto with cc_scope shelvedb. all: reflexivity. }
       all: f_equal.
       2:{
-        ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. rasimpl.
+        unfold close. rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
+        unfold funcomp. rewrite psubst_SS. rasimpl.
         erewrite rinstInst'_cterm. reflexivity.
       }
       cbn. unfold cty_lift. f_equal. f_equal. all: f_equal. all: unfold close.
-      all: ssimpl.
+      all: rasimpl.
+      all: rewrite !substSubst_cterm.
       all: eapply ext_cterm. all: intros [].
       all: cbn. 1,3: reflexivity.
-      all: ssimpl.
+      all: unfold funcomp.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
       all: rasimpl. all: reflexivity.
     + f_equal. all: f_equal.
@@ -1495,13 +1504,13 @@ Proof.
       2:{ rasimpl. reflexivity. }
       2:{
         rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
+        unfold funcomp. rewrite psubst_SS. rasimpl. reflexivity.
       }
       cbn. f_equal. f_equal. all: f_equal. all: f_equal.
       all: rasimpl.
       all: eapply ext_cterm. all: intros [].
       all: cbn. 1,3: reflexivity.
-      all: ssimpl.
+      all: unfold funcomp.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
     + f_equal. all: f_equal.
       2:{ rasimpl. reflexivity. }
@@ -1511,13 +1520,13 @@ Proof.
       2:{ rasimpl. reflexivity. }
       2:{
         rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
+        unfold funcomp. rewrite psubst_SS. rasimpl. reflexivity.
       }
       cbn. f_equal. f_equal. all: f_equal. all: f_equal.
       all: rasimpl.
       all: eapply ext_cterm. all: intros [].
       all: cbn. 1,3: reflexivity.
-      all: ssimpl.
+      all: unfold funcomp.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
     + f_equal. all: f_equal.
       2:{ rasimpl. reflexivity. }
@@ -1527,13 +1536,14 @@ Proof.
       2:{ rasimpl. reflexivity. }
       2:{
         rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
+        unfold funcomp. rewrite psubst_SS. rasimpl. reflexivity.
       }
       cbn. f_equal. f_equal. all: f_equal. all: f_equal.
-      all: ssimpl.
+      all: rasimpl.
+      all: repeat rewrite ?substSubst_cterm, ?substRen_cterm.
       all: eapply ext_cterm. all: intros [].
       all: cbn. 1,3: reflexivity.
-      all: ssimpl.
+      all: unfold funcomp.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
       all: rasimpl.
       * rewrite rinstInst'_cterm. reflexivity.
@@ -1544,32 +1554,34 @@ Proof.
       2:{ unshelve typeclasses eauto with cc_scope shelvedb. all: reflexivity. }
       all: f_equal.
       2:{
-        ssimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. rasimpl.
+        unfold close. rasimpl. eapply ext_cterm.
+        intros [| []]. all: cbn. 1,2: reflexivity.
+        unfold funcomp. rewrite psubst_SS. rasimpl.
         erewrite rinstInst'_cterm. reflexivity.
       }
       cbn. unfold cty_lift. f_equal. f_equal. all: f_equal. all: unfold close.
-      all: ssimpl.
+      all: rasimpl.
+      all: rewrite !substSubst_cterm.
       all: eapply ext_cterm. all: intros [].
       all: cbn. 1,3: reflexivity.
-      all: ssimpl.
+      all: unfold funcomp.
       all: erewrite erase_ren ; eauto using rscoping_S, rscoping_comp_S.
       all: rasimpl. all: reflexivity.
     + f_equal. all: f_equal. 1: f_equal.
       * rasimpl. reflexivity.
       * rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
+        unfold funcomp. rewrite psubst_SS. rasimpl. reflexivity.
     + f_equal. all: f_equal. 1: f_equal.
       * rasimpl. reflexivity.
       * rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
+        unfold funcomp. rewrite psubst_SS. rasimpl. reflexivity.
     + f_equal. all: f_equal. 1: f_equal.
       * rasimpl. reflexivity.
       * rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-        ssimpl. rewrite psubst_SS. ssimpl. reflexivity.
+        unfold funcomp. rewrite psubst_SS. rasimpl. reflexivity.
     + f_equal. unfold close.
       rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-      ssimpl. rewrite psubst_SS. rasimpl.
+      unfold funcomp. rewrite psubst_SS. rasimpl.
       rewrite rinstInst'_cterm. reflexivity.
   - cbn.
     erewrite IHt1. 2,3: eassumption.
@@ -1582,7 +1594,8 @@ Proof.
     destruct_ifs. all: mode_eqs.
     + cbn. f_equal. unfold close. rasimpl.
       eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
-      ssimpl. rewrite psubst_SS. rasimpl.
+      unfold funcomp.
+      rewrite psubst_SS. rasimpl.
       erewrite rinstInst'_cterm. reflexivity.
     + cbn. unfold plam. f_equal. f_equal.
       * rasimpl. reflexivity.
@@ -1962,8 +1975,8 @@ Proof.
         destruct (isKind mx) eqn:e3. all: mode_eqs.
         -- cbn. rasimpl. f_equal. assumption.
         -- destruct mx. all: try discriminate.
-          ++ cbn. ssimpl. f_equal. assumption.
-          ++ cbn. ssimpl. f_equal. assumption.
+          ++ cbn. rasimpl. f_equal. assumption.
+          ++ cbn. rasimpl. f_equal. assumption.
       * set (p := Nat.div2 n) in *.
         rewrite en in hx. rewrite nth_error_param_vreg in hx.
         destruct nth_error as [mx|] eqn:e1. 2: discriminate.
@@ -1973,7 +1986,7 @@ Proof.
         destruct PeanoNat.Nat.odd eqn:eodd.
         2:{ rewrite en in eodd. rewrite odd_vreg in eodd. discriminate. }
         destruct (isProp mx) eqn:e2.
-        -- mode_eqs. cbn. ssimpl. f_equal. assumption.
+        -- mode_eqs. cbn. rasimpl. f_equal. assumption.
         -- unfold relv, ghv. rewrite e1.
           destruct_ifs.
           ++ rewrite en. reflexivity.
@@ -2006,10 +2019,10 @@ Proof.
         1:{ rewrite en in eodd. rewrite odd_vpar in eodd. discriminate. }
         destruct (isProp mx) eqn:e2. 1: discriminate.
         destruct (isKind mx) eqn:e3. all: mode_eqs.
-        -- cbn. ssimpl. f_equal. assumption.
+        -- cbn. rasimpl. f_equal. assumption.
         -- destruct mx. all: try discriminate.
-          ++ cbn. ssimpl. f_equal. assumption.
-          ++ cbn. ssimpl. f_equal. assumption.
+          ++ cbn. rasimpl. f_equal. assumption.
+          ++ cbn. rasimpl. f_equal. assumption.
       * set (p := Nat.div2 n) in *.
         rewrite en in hx. rewrite nth_error_param_vreg in hx.
         destruct nth_error as [mx|] eqn:emx. 2: discriminate.
@@ -2019,7 +2032,7 @@ Proof.
         destruct PeanoNat.Nat.odd eqn:eodd.
         2:{ rewrite en in eodd. rewrite odd_vreg in eodd. discriminate. }
         destruct (isProp mx) eqn:e2.
-        -- mode_eqs. cbn. ssimpl. f_equal. assumption.
+        -- mode_eqs. cbn. rasimpl. f_equal. assumption.
         -- unfold relv, ghv. rewrite emx.
           destruct_ifs.
           ++ rewrite en. reflexivity.
@@ -2050,10 +2063,10 @@ Proof.
         1:{ rewrite en in eodd. rewrite odd_vpar in eodd. discriminate. }
         destruct (isProp mx) eqn:e3. 1: discriminate.
         destruct (isKind mx) eqn:e4. all: mode_eqs.
-        -- cbn. ssimpl. f_equal. assumption.
+        -- cbn. rasimpl. f_equal. assumption.
         -- destruct mx. all: try discriminate.
-          ++ cbn. ssimpl. f_equal. assumption.
-          ++ cbn. ssimpl. f_equal. assumption.
+          ++ cbn. rasimpl. f_equal. assumption.
+          ++ cbn. rasimpl. f_equal. assumption.
       * set (p := Nat.div2 n) in *.
         rewrite en in hx. rewrite nth_error_param_vreg in hx.
         destruct nth_error as [mx|] eqn:emx. 2: discriminate.
@@ -2063,7 +2076,7 @@ Proof.
         destruct PeanoNat.Nat.odd eqn:eodd.
         2:{ rewrite en in eodd. rewrite odd_vreg in eodd. discriminate. }
         destruct (isProp mx) eqn:e3.
-        -- mode_eqs. cbn. ssimpl. f_equal. assumption.
+        -- mode_eqs. cbn. rasimpl. f_equal. assumption.
         -- unfold relv, ghv. rewrite emx.
           destruct_ifs.
           ++ rewrite en. reflexivity.
@@ -2091,10 +2104,10 @@ Proof.
         1:{ rewrite en in eodd. rewrite odd_vpar in eodd. discriminate. }
         destruct (isProp mx) eqn:e3. 1: discriminate.
         destruct (isKind mx) eqn:e4. all: mode_eqs.
-        -- cbn. ssimpl. f_equal. assumption.
+        -- cbn. rasimpl. f_equal. assumption.
         -- destruct mx. all: try discriminate.
-          ++ cbn. ssimpl. f_equal. assumption.
-          ++ cbn. ssimpl. f_equal. assumption.
+          ++ cbn. rasimpl. f_equal. assumption.
+          ++ cbn. rasimpl. f_equal. assumption.
       * set (p := Nat.div2 n) in *.
         rewrite en in hx. rewrite nth_error_param_vreg in hx.
         destruct nth_error as [mx|] eqn:emx. 2: discriminate.
@@ -2104,7 +2117,7 @@ Proof.
         destruct PeanoNat.Nat.odd eqn:eodd.
         2:{ rewrite en in eodd. rewrite odd_vreg in eodd. discriminate. }
         destruct (isProp mx) eqn:e3.
-        -- mode_eqs. cbn. ssimpl. f_equal. assumption.
+        -- mode_eqs. cbn. rasimpl. f_equal. assumption.
         -- unfold relv, ghv. rewrite emx.
           destruct_ifs.
           ++ rewrite en. reflexivity.
@@ -2245,8 +2258,7 @@ Proof.
         erewrite !param_ren. 2-7: eauto using rscoping_S, rscoping_comp_S.
         change (vreg ⋅ ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
         change (vreg ⋅ ⟦ ?G | ?t ⟧v) with (⟦ G | t ⟧pv).
-        ssimpl. rewrite pren_S_pw. ssimpl.
-        rewrite <- !rinstInst'_cterm.
+        rasimpl. rewrite pren_S_pw. rasimpl.
         change (S >> vreg) with (vreg >> S >> S).
         rewrite <- !funcomp_assoc.
         change (S >> vreg) with (vreg >> S >> S).
@@ -2267,8 +2279,7 @@ Proof.
         erewrite !param_ren. 2-7: eauto using rscoping_S, rscoping_comp_S.
         change (vreg ⋅ ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
         change (vreg ⋅ ⟦ ?G | ?t ⟧v) with (⟦ G | t ⟧pv).
-        ssimpl. rewrite pren_S_pw. ssimpl.
-        rewrite <- !rinstInst'_cterm.
+        rasimpl. rewrite pren_S_pw. rasimpl.
         change (S >> vreg) with (vreg >> S >> S).
         rewrite <- !funcomp_assoc.
         change (S >> vreg) with (vreg >> S >> S).
@@ -2290,8 +2301,7 @@ Proof.
         erewrite !param_ren. 2-7: eauto using rscoping_S, rscoping_comp_S.
         change (vreg ⋅ ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
         change (vreg ⋅ ⟦ ?G | ?t ⟧v) with (⟦ G | t ⟧pv).
-        ssimpl. rewrite pren_S_pw. ssimpl.
-        rewrite <- !rinstInst'_cterm.
+        rasimpl. rewrite pren_S_pw. rasimpl.
         change (S >> vreg) with (vreg >> S >> S).
         rewrite <- !funcomp_assoc.
         change (S >> vreg) with (vreg >> S >> S).
@@ -3038,9 +3048,8 @@ Proof.
                   * {
                     ertype. eapply ccmeta_conv.
                     - ertype. eapply ccmeta_conv. 1: ertype.
-                      cbn. lhs_ssimpl. f_equal. rasimpl. reflexivity.
-                    - cbn. lhs_ssimpl. f_equal. rasimpl.
-                      rewrite rinstInst'_cterm. reflexivity.
+                      cbn. rasimpl. reflexivity.
+                    - cbn. rasimpl. reflexivity.
                   }
                   * cbn. rasimpl. reflexivity.
                 + cbn. reflexivity.
@@ -3086,9 +3095,8 @@ Proof.
                         * {
                           ertype. eapply ccmeta_conv.
                           - ertype. eapply ccmeta_conv. 1: ertype.
-                            cbn. lhs_ssimpl. f_equal. rasimpl. reflexivity.
-                          - cbn. lhs_ssimpl. f_equal. rasimpl.
-                            rewrite rinstInst'_cterm. reflexivity.
+                            cbn. rasimpl. reflexivity.
+                          - cbn. rasimpl. reflexivity.
                         }
                         * cbn. rasimpl. reflexivity.
                       + cbn. reflexivity.
@@ -3103,9 +3111,8 @@ Proof.
             constructor. 2: econv.
             constructor.
           }
-          cbn. lhs_ssimpl. eapply cconv_trans. 1: constructor.
-          cbn. lhs_ssimpl. rewrite <- !funcomp_assoc.
-          rewrite <- !rinstInst'_cterm. econv.
+          cbn. rasimpl. eapply cconv_trans. 1: constructor.
+          cbn. rasimpl. econv.
         - ertype.
           + eapply ccmeta_conv. 1: ertype.
             cbn. reflexivity.
@@ -3116,8 +3123,7 @@ Proof.
                 + ertype. eapply ccmeta_conv. 1: ertype.
                   cbn. rasimpl. reflexivity.
                 + cbn. rasimpl. reflexivity.
-              - cbn. lhs_ssimpl. rewrite <- funcomp_assoc.
-                rewrite <- !rinstInst'_cterm. reflexivity.
+              - cbn. rasimpl. reflexivity.
             }
             * cbn. reflexivity.
       }
@@ -4057,7 +4063,7 @@ Proof.
                 eapply cconv_trans. 1: constructor.
                 apply ccmeta_refl. f_equal.
                 change (epm_lift ?t) with (vreg ⋅ t).
-                ssimpl. rewrite rinstInst'_cterm.
+                unfold close. rasimpl.  rewrite rinstInst'_cterm.
                 eapply ext_cterm_scoped. 1: apply erase_scoping.
                 intros [] hx. 1: discriminate.
                 cbn. reflexivity.
@@ -4117,11 +4123,11 @@ Proof.
                     - ertype.
                   }
               - cbn. unfold Be. change (epm_lift ?t) with (vreg ⋅ t).
-                ssimpl. f_equal. rewrite rinstInst'_cterm.
-                ssimpl. eapply ext_cterm_scoped. 1: apply erase_scoping.
+                rasimpl. f_equal. rewrite rinstInst'_cterm.
+                eapply ext_cterm_scoped. 1: apply erase_scoping.
                 intros [] hx. 1: reflexivity.
-                rasimpl. change (vreg (S ?x)) with (S (S (vreg x))).
-                cbn. rasimpl. reflexivity.
+                unfold funcomp. cbn.
+                reflexivity.
             }
         - instantiate (2 := if isKind m then _ else _).
           instantiate (1 := if isKind m then _ else _).

--- a/theories/Param.v
+++ b/theories/Param.v
@@ -4262,10 +4262,6 @@ Ltac hide_ctx C :=
   | |- ?G ⊢ᶜ _ ≡ _ => set (C := G)
   end.
 
-Ltac lhs_ssimpl' :=
-  let G := fresh "G" in
-  hide_ctx G ; lhs_ssimpl ; subst G.
-
 Ltac lhs_hnf :=
   lazymatch goal with
   | |- _ ⊢ᶜ ?t ≡ _ => let t' := eval hnf in t in change t with t'
@@ -4396,22 +4392,23 @@ Proof.
         - destruct_if emp. 1:{ mode_eqs. discriminate. }
           rewrite andb_false_r.
           unfold pmPiNP. cbn. eapply cconv_trans. 1: constructor.
-          cbn. ssimpl. econv.
+          cbn. unfold close. rasimpl. econv.
           + apply ccmeta_refl. eapply ext_cterm.
             intros [| []]. all: reflexivity.
           + apply ccmeta_refl.
-            change (epm_lift ?t) with (vreg ⋅ t). ssimpl.
+            change (epm_lift ?t) with (vreg ⋅ t). unfold close. rasimpl.
             eapply ext_cterm_scoped. 1: apply erase_scoping.
             intros [] hx. 1: discriminate.
             rasimpl. change (vreg (S ?x)) with (S (S (vreg x))).
             rasimpl. reflexivity.
         - destruct_if eg.
           + mode_eqs. cbn. eapply cconv_trans. 1: constructor.
-            cbn. ssimpl. econv.
+            cbn. rasimpl. unfold close. rasimpl. econv.
             * apply ccmeta_refl. eapply ext_cterm.
               intros [| []]. all: reflexivity.
             * apply ccmeta_refl.
-              change (rpm_lift ?t) with (vreg ⋅ t). ssimpl.
+              change (rpm_lift ?t) with (vreg ⋅ t). rasimpl.
+              unfold close. rasimpl.
               eapply ext_cterm_scoped. 1: apply revive_scoping.
               intros [] hx. 1: discriminate.
               rasimpl. change (vreg (S ?x)) with (S (S (vreg x))).
@@ -4595,8 +4592,7 @@ Proof.
           destruct (isGhost m) eqn:eg. 1:{ mode_eqs. discriminate. }
           simpl. unfold pmPiNP. rewrite erm. rewrite exp. apply cconv_sym.
           eapply cconv_trans. 1: constructor.
-          unfold pPi. cbn. ssimpl.
-          rewrite <- rinstInst'_cterm. econv.
+          unfold pPi. cbn. rasimpl. econv.
           eapply cconv_trans.
           2:{ destruct_if ekx. all: econv. }
           econv.
@@ -4622,8 +4618,7 @@ Proof.
           + mode_eqs. simpl. unfold pmPiNP. rewrite exp.
             apply cconv_sym. eapply cconv_trans. 1: constructor.
             simpl. rewrite andb_false_r.
-            cbn. unfold pPi. ssimpl.
-            rewrite <- rinstInst'_cterm. econv.
+            cbn. unfold pPi. rasimpl. econv.
             eapply cconv_trans.
             2:{ destruct_if ekx. all: econv. }
             econv.
@@ -4921,8 +4916,8 @@ Proof.
         eapply cconv_trans. 1: constructor.
         instantiate (1 := if isProp mx then _ else _).
         destruct_if epx.
-        + cbn. lhs_ssimpl. econv.
-        + cbn. lhs_ssimpl. rewrite <- rinstInst'_cterm.
+        + cbn. rasimpl. unfold close. rasimpl. econv.
+        + cbn. rasimpl.
           econstructor. 1: econv.
           econstructor. 1: econv.
           econstructor. 1: econv.
@@ -4938,9 +4933,9 @@ Proof.
           instantiate (1 := if isProp mx then _ else _).
           destruct (isProp mx) eqn:epx.
           * mode_eqs. cbn. rasimpl. econv.
-          * unfold pPi. cbn. lhs_ssimpl.
+          * unfold pPi. cbn. rasimpl.
             rewrite andb_false_r. cbn.
-            rewrite <- rinstInst'_cterm. econv.
+            econv.
         + destruct m. all: try discriminate.
           unfold pmPi. cbn. econv.
     }
@@ -4972,7 +4967,8 @@ Proof.
                 * cbn. change (epm_lift ?t) with (vreg ⋅ t). cbn.
                   econstructor. 2: econv.
                   apply cconv_sym. eapply cconv_trans. 1: constructor.
-                  econv. apply ccmeta_refl. ssimpl.
+                  econv. apply ccmeta_refl. rasimpl.
+                  unfold close. rasimpl.
                   eapply ext_cterm_scoped. 1: apply erase_scoping.
                   intros [| []] hx. 1: discriminate. all: reflexivity.
                 * {
@@ -5001,7 +4997,8 @@ Proof.
                 * cbn. econstructor. 2: econv.
                   change (epm_lift ?t) with (vreg ⋅ t). cbn.
                   apply cconv_sym. eapply cconv_trans. 1: constructor.
-                  econv. apply ccmeta_refl. ssimpl.
+                  econv. apply ccmeta_refl. rasimpl.
+                  unfold close. rasimpl.
                   eapply ext_cterm_scoped. 1: apply erase_scoping.
                   intros [| []] hx. 1: discriminate. all: reflexivity.
                 * {
@@ -5025,7 +5022,7 @@ Proof.
             - ertype. eapply ccmeta_conv.
               + ertype.
               + cbn. reflexivity.
-            - lhs_ssimpl. instantiate (1 := if isKind mx then _ else _).
+            - rasimpl. instantiate (1 := if isKind mx then _ else _).
               destruct (isKind mx) eqn:ek. all: reflexivity.
           }
           * {
@@ -5070,7 +5067,8 @@ Proof.
                     change (epm_lift ?t) with (vreg ⋅ t).
                     cbn. eapply cconv_trans. 1: constructor.
                     econv. apply ccmeta_refl.
-                    ssimpl. eapply ext_cterm_scoped. 1: apply erase_scoping.
+                    rasimpl. unfold close. rasimpl.
+                    eapply ext_cterm_scoped. 1: apply erase_scoping.
                     intros [| []] hx. 1: discriminate. all: reflexivity.
                   - ertype. eapply ccmeta_conv.
                     + eapply ctyping_subst. 2: ertype.
@@ -5131,14 +5129,15 @@ Proof.
             - ertype. econstructor.
               + eapply ctyping_subst. 2: ertype.
                 constructor.
-                * ssimpl. apply crtyping_typing. ertype.
+                * rasimpl. apply crtyping_typing. ertype.
                 * cbn. split. 1: ertype.
                   eapply ccmeta_conv. 1: ertype.
                   cbn. rasimpl. rewrite rinstInst'_cterm. reflexivity.
               + cbn. apply cconv_sym. change (epm_lift ?t) with (vreg ⋅ t).
                 cbn. econstructor. 2: econv.
                 eapply cconv_trans. 1: constructor.
-                econv. apply ccmeta_refl. ssimpl.
+                econv. apply ccmeta_refl. rasimpl.
+                unfold close. rasimpl.
                 eapply ext_cterm_scoped. 1: apply erase_scoping.
                 intros [| []] hx. 1: discriminate. all: reflexivity.
               + ertype. eapply ccmeta_conv.
@@ -5284,13 +5283,13 @@ Proof.
         - instantiate (2 := if isKind mx then _ else _).
           instantiate (1 := if rm then _ else _).
           destruct rm eqn:er.
-          + cbn. lhs_ssimpl. reflexivity.
+          + cbn. rasimpl. reflexivity.
           + instantiate (1 := if isGhost m then _ else _).
             destruct (isGhost m) eqn:eg.
-            * cbn. lhs_ssimpl. reflexivity.
+            * cbn. rasimpl. reflexivity.
             * {
               destruct (isKind mx) eqn:ekx.
-              - cbn. lhs_ssimpl. reflexivity.
+              - cbn. rasimpl. reflexivity.
               - cbn. rasimpl. reflexivity.
             }
       }
@@ -5359,14 +5358,16 @@ Proof.
           eapply ext_cterm_scoped. 1:{ apply param_scoping. eassumption. }
           intros [| []] hx. all: cbn.
           + reflexivity.
-          + ssimpl. reflexivity.
+          + rasimpl. reflexivity.
           + apply psubst_SS_id. assumption.
-        - mode_eqs. cbn. ssimpl. f_equal.
+        - mode_eqs. cbn. rasimpl. f_equal.
           erewrite param_subst.
           2:{ apply sscoping_one. escope. }
           2: apply sscoping_comp_one.
+          rasimpl.
           eapply ext_cterm_scoped. 1:{ apply param_scoping. eassumption. }
-          intros [| []] hx. all: cbn. 1,2: reflexivity.
+          intros [| []] hx. all: cbn. 1: reflexivity.
+          1:{ rasimpl. reflexivity. }
           apply psubst_SS_id. assumption.
         - destruct m. all: try discriminate.
           rasimpl.
@@ -5401,20 +5402,22 @@ Proof.
           + cbn in hx. discriminate.
           + reflexivity.
           + apply psubst_SS_id. assumption.
-        - mode_eqs. cbn. ssimpl. f_equal.
+        - mode_eqs. cbn. rasimpl. f_equal.
           erewrite param_subst.
           2:{ apply sscoping_one. escope. }
           2: apply sscoping_comp_one.
+          unfold close. rasimpl.
           eapply ext_cterm_scoped. 1:{ apply param_scoping. eassumption. }
           intros [| []] hx. all: cbn.
           + discriminate.
           + reflexivity.
           + apply psubst_SS_id. assumption.
         - destruct m. all: try discriminate.
-          ssimpl.
+          rasimpl.
           erewrite param_subst.
           2:{ apply sscoping_one. escope. }
           2: apply sscoping_comp_one.
+          unfold close. rasimpl.
           eapply ext_cterm_scoped. 1:{ apply param_scoping. eassumption. }
           intros [| []] hx. all: cbn.
           + discriminate.
@@ -5447,9 +5450,8 @@ Proof.
       2:{
         eapply cconv_trans. 1: constructor.
         cbn. econstructor.
-        - lhs_ssimpl. econv.
-        - lhs_ssimpl. econstructor.
-          1:{ rewrite <- rinstInst'_cterm. econv. }
+        - rasimpl. econv.
+        - rasimpl. econstructor. 1: econv.
           eapply cconv_trans. 1: constructor.
           cbn. econstructor. 2: econv.
           instantiate (1 := (S >> S) ⋅ ⟦ sc Γ | P ⟧pτ).
@@ -5478,20 +5480,19 @@ Proof.
       2:{
         eapply cconv_trans. 1: constructor.
         cbn. econstructor.
-        - lhs_ssimpl. econv.
-        - lhs_ssimpl. econstructor.
-          + rewrite <- rinstInst'_cterm. econv.
-          + econstructor. 2: econv.
-            econstructor. 2: econv.
-            econstructor. all: apply ccmeta_refl.
-            * hide_rhs rhs. erewrite param_ren.
-              2: apply rscoping_S.
-              2: apply rscoping_comp_S.
-              rasimpl. rewrite pren_S_pw. rasimpl.
-              unfold rhs. reflexivity.
-            * hide_rhs rhs.
-              rewrite rpm_lift_eq. cbn.
-              unfold rhs. reflexivity.
+        - rasimpl. econv.
+        - rasimpl. econstructor. 1: econv.
+          econstructor. 2: econv.
+          econstructor. 2: econv.
+          econstructor. all: apply ccmeta_refl.
+          + hide_rhs rhs. erewrite param_ren.
+            2: apply rscoping_S.
+            2: apply rscoping_comp_S.
+            rasimpl. rewrite pren_S_pw. rasimpl.
+            unfold rhs. reflexivity.
+          + hide_rhs rhs.
+            rewrite rpm_lift_eq. cbn.
+            unfold rhs. reflexivity.
       }
       2:{
         etype.
@@ -5565,9 +5566,8 @@ Proof.
       2:{
         eapply cconv_trans. 1: constructor.
         cbn. econstructor.
-        - lhs_ssimpl. econv.
-        - lhs_ssimpl. econstructor.
-          1:{ rewrite <- rinstInst'_cterm. econv. }
+        - rasimpl. econv.
+        - rasimpl. econstructor. 1: econv.
           eapply cconv_trans. 1: constructor.
           cbn. econv.
       }
@@ -5586,7 +5586,7 @@ Proof.
         erewrite param_ren.
         2: apply rscoping_S.
         2: apply rscoping_comp_S.
-        lhs_ssimpl. rewrite pren_S_pw.
+        rasimpl. rewrite pren_S_pw.
         change (rpm_lift (cvar 0)) with (vreg ⋅ (cvar 0)).
         cbn. reflexivity.
       }
@@ -5709,7 +5709,7 @@ Proof.
       eapply ctype_conv in IHh5.
       2:{
         eapply cconv_trans. 1: constructor.
-        cbn. lhs_ssimpl. rewrite <- rinstInst'_cterm.
+        cbn. rasimpl.
         econstructor. 1: econv.
         econstructor. 1: econv.
         eapply cconv_trans. 1: constructor.
@@ -5720,7 +5720,7 @@ Proof.
         - eapply ccmeta_conv.
           + etype. eapply ccmeta_conv.
             * eapply ctyping_ren. all: etype.
-            * cbn. lhs_ssimpl. reflexivity.
+            * cbn. rasimpl. reflexivity.
           + cbn. reflexivity.
         - econstructor.
           + eapply ctyping_ren. all: etype.
@@ -5749,7 +5749,7 @@ Proof.
       eapply ctype_conv in IHh5.
       2:{
         eapply cconv_trans. 1: constructor.
-        cbn. lhs_ssimpl. rewrite <- rinstInst'_cterm.
+        cbn. rasimpl.
         econstructor. 1: econv.
         econstructor. 1: econv.
         eapply cconv_trans. 1: constructor.
@@ -5762,7 +5762,7 @@ Proof.
         - eapply ccmeta_conv.
           + etype. eapply ccmeta_conv.
             * eapply ctyping_ren. all: etype.
-            * cbn. lhs_ssimpl. reflexivity.
+            * cbn. rasimpl. reflexivity.
           + cbn. reflexivity.
         - econstructor.
           + eapply ctyping_ren. all: etype.
@@ -5792,7 +5792,7 @@ Proof.
       eapply ctype_conv in IHh5.
       2:{
         eapply cconv_trans. 1: constructor.
-        cbn. lhs_ssimpl. rewrite <- rinstInst'_cterm.
+        cbn. rasimpl.
         econstructor. 1: econv.
         econstructor. 1: econv.
         eapply cconv_trans. 1: constructor.
@@ -6188,7 +6188,7 @@ Proof.
     eapply ctype_conv in IHh2.
     2:{
       unfold pmPiNP. eapply cconv_trans. 1: constructor.
-      cbn. lhs_ssimpl. econstructor.
+      cbn. rasimpl. econstructor.
       - rewrite epm_lift_eq. cbn. econv.
       - econstructor. 1: econv.
         instantiate (1 := if isProp m then _ else cPi _ _ (if isKind m then _ else _)).
@@ -6257,35 +6257,35 @@ Proof.
         clear.
         unfold pmPiNP. cbn. eapply cconv_trans. 1: constructor.
         cbn. constructor.
-        1:{ lhs_ssimpl. rewrite epm_lift_eq. cbn. econv. }
+        1:{ rasimpl. rewrite epm_lift_eq. cbn. econv. }
         constructor. 1: econv.
         eapply cconv_trans. 1: constructor.
         cbn. constructor.
         1:{
-          lhs_ssimpl. change (epm_lift ?t) with (vreg ⋅ t).
+          rasimpl. change (epm_lift ?t) with (vreg ⋅ t).
           cbn. erewrite erase_ren. 2,3: eauto using rscoping_S, rscoping_comp_S.
-          lhs_ssimpl. constructor. constructor. 2: econv.
+          rasimpl. constructor. constructor. 2: econv.
           apply ccmeta_refl. etransitivity.
           - eapply ext_cterm_scoped with (θ := vreg >> S >> S >> cvar).
             1: apply erase_scoping.
             clear. intros [|] hx.
-            + ssimpl. unfold vreg. cbn. ssimpl. reflexivity.
-            + ssimpl. change (vreg (S ?x)) with (S (S (vreg x))).
+            + rasimpl. unfold vreg. cbn. rasimpl. reflexivity.
+            + rasimpl. unfold shift, funcomp. cbn.
+              change (vreg (S ?x)) with (S (S (vreg x))).
               change (vreg (S ?x)) with (S (S (vreg x))).
               cbn. reflexivity.
           - rewrite <- rinstInst'_cterm.
             rewrite <- renRen_cterm. rewrite <- renRen_cterm.
-            rewrite <- epm_lift_eq. lhs_ssimpl. reflexivity.
+            rewrite <- epm_lift_eq. rasimpl. reflexivity.
         }
         constructor.
         1:{
-          lhs_ssimpl'. change (epm_lift (cvar 0)) with (cvar 1).
+          rasimpl. change (epm_lift (cvar 0)) with (cvar 1).
           erewrite param_ren. 2,3: eauto using rscoping_S, rscoping_comp_S.
-          lhs_ssimpl'. constructor. 2: econv.
+          rasimpl. constructor. 2: econv.
           constructor. 2: econv.
           constructor. 2: econv.
-          apply ccmeta_refl. rewrite pren_S_pw. lhs_ssimpl.
-          rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
+          apply ccmeta_refl. rewrite pren_S_pw. rasimpl.
           reflexivity.
         }
         constructor. 2: econv.
@@ -6293,8 +6293,7 @@ Proof.
         constructor.
         - erewrite !param_ren. 2-7: eauto using rscoping_S, rscoping_comp_S.
           rewrite !pren_S_pw. apply ccmeta_refl.
-          lhs_ssimpl. rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-          reflexivity.
+          rasimpl. reflexivity.
         - apply ccmeta_refl.
           change (epm_lift ?t) with (vreg ⋅ t). cbn.
           reflexivity.
@@ -6336,13 +6335,15 @@ Proof.
                   * apply ccmeta_refl.
                     erewrite erase_ren.
                     2,3: eauto using rscoping_S, rscoping_comp_S.
-                    lhs_ssimpl. rewrite <- renRen_cterm.
+                    rasimpl. rewrite <- renRen_cterm.
                     rewrite <- epm_lift_eq. reflexivity.
                   * apply ccmeta_refl.
                     erewrite !erase_ren.
                     2-5: eauto using rscoping_S, rscoping_comp_S.
-                    lhs_ssimpl. rewrite <- renRen_cterm.
-                    rewrite <- epm_lift_eq. reflexivity.
+                    rasimpl. rewrite <- renRen_cterm.
+                    rewrite <- epm_lift_eq.
+                    unfold_funcomp. cbn.
+                    reflexivity.
                 + ertype.
                   * {
                     eapply ccmeta_conv.
@@ -6362,8 +6363,7 @@ Proof.
                         * cbn. reflexivity.
                     - reflexivity.
                   }
-              - cbn. f_equal. ssimpl. rewrite <- !funcomp_assoc.
-                rewrite <- rinstInst'_cterm. reflexivity.
+              - cbn. f_equal. rasimpl. reflexivity.
             }
             cbn. eapply ccmeta_conv.
             * {
@@ -6373,12 +6373,11 @@ Proof.
                   * {
                     eapply ccmeta_conv.
                     - ertype.
-                    - cbn. lhs_ssimpl. reflexivity.
+                    - cbn. rasimpl. unfold_funcomp. cbn. reflexivity.
                   }
                   * eapply ccmeta_conv. 1: ertype.
                     reflexivity.
-                + cbn. lhs_ssimpl. rewrite <- !funcomp_assoc.
-                  rewrite <- rinstInst'_cterm. reflexivity.
+                + cbn. rasimpl. reflexivity.
               - eapply ccmeta_conv.
                 + ertype.
                 + reflexivity.
@@ -6405,16 +6404,16 @@ Proof.
         1:{
           apply cconv_sym. erewrite erase_ren.
           2-3: eauto using rscoping_S, rscoping_comp_S.
-          lhs_ssimpl. rewrite <- renRen_cterm. rewrite <- epm_lift_eq.
+          rasimpl. rewrite <- renRen_cterm. rewrite <- epm_lift_eq.
           econv.
         }
         apply cconv_sym. constructor. constructor.
-        2:{ lhs_ssimpl. econv. }
+        2:{ rasimpl. unfold_funcomp. cbn. econv. }
         apply ccmeta_refl.
         erewrite !erase_ren.
-          2-5: eauto using rscoping_S, rscoping_comp_S.
-          lhs_ssimpl. rewrite <- renRen_cterm. rewrite <- epm_lift_eq.
-          reflexivity.
+        2-5: eauto using rscoping_S, rscoping_comp_S.
+        rasimpl. rewrite <- renRen_cterm. rewrite <- epm_lift_eq.
+        reflexivity.
       }
       2:{
         ertype.
@@ -6446,48 +6445,47 @@ Proof.
         clear.
         unfold pmPiNP. cbn. eapply cconv_trans. 1: constructor.
         cbn. apply cconv_sym. apply ccong_Pi.
-        1:{ apply cconv_sym. lhs_ssimpl. rewrite epm_lift_eq. cbn. econv. }
+        1:{ apply cconv_sym. rasimpl. rewrite epm_lift_eq. cbn. econv. }
         apply ccong_Pi. 1: econv.
         apply cconv_sym.
         eapply cconv_trans. 1: constructor.
         cbn. apply cconv_sym. apply ccong_Pi.
         1:{
           apply cconv_sym.
-          lhs_ssimpl. change (epm_lift ?t) with (vreg ⋅ t).
+          rasimpl. change (epm_lift ?t) with (vreg ⋅ t).
           cbn. erewrite erase_ren. 2,3: eauto using rscoping_S, rscoping_comp_S.
-          lhs_ssimpl. constructor. constructor. 2: econv.
+          rasimpl. constructor. constructor. 2: econv.
           apply ccmeta_refl. etransitivity.
           - eapply ext_cterm_scoped with (θ := vreg >> S >> S >> cvar).
             1: apply erase_scoping.
             clear. intros [|] hx.
-            + ssimpl. unfold vreg. cbn. ssimpl. reflexivity.
-            + ssimpl. change (vreg (S ?x)) with (S (S (vreg x))).
+            + rasimpl. unfold vreg, shift, funcomp. cbn. reflexivity.
+            + rasimpl. unfold shift, funcomp. cbn.
+              change (vreg (S ?x)) with (S (S (vreg x))).
               change (vreg (S ?x)) with (S (S (vreg x))).
               cbn. reflexivity.
-          - rewrite <- rinstInst'_cterm.
-            rewrite <- renRen_cterm. rewrite <- renRen_cterm.
-            rewrite <- epm_lift_eq. lhs_ssimpl. reflexivity.
+          - rasimpl.
+            rewrite <- renRen_cterm.
+            rewrite <- epm_lift_eq. reflexivity.
         }
         apply ccong_Pi.
         1:{
           apply cconv_sym.
-          lhs_ssimpl'. change (epm_lift (cvar 0)) with (cvar 1).
+          rasimpl. change (epm_lift (cvar 0)) with (cvar 1).
           erewrite param_ren. 2,3: eauto using rscoping_S, rscoping_comp_S.
-          lhs_ssimpl'. rewrite pren_S_pw. constructor. 2: econv.
+          rasimpl. rewrite pren_S_pw. constructor. 2: econv.
           constructor. 2: econv.
-          constructor. 2: econv.
-          apply ccmeta_refl. lhs_ssimpl.
-          rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
+          constructor. 2:{ unfold_funcomp. econv. }
+          apply ccmeta_refl. rasimpl.
           reflexivity.
         }
         apply cconv_sym.
-        constructor. 2:{ lhs_ssimpl. econv. }
+        constructor. 2:{ rasimpl. econv. }
         constructor. 2: econv.
         constructor.
         - erewrite !param_ren. 2-5: eauto using rscoping_S, rscoping_comp_S.
           rewrite !pren_S_pw. apply ccmeta_refl.
-          lhs_ssimpl. rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-          reflexivity.
+          rasimpl. reflexivity.
         - apply ccmeta_refl.
           change (epm_lift ?t) with (vreg ⋅ t). cbn.
           reflexivity.
@@ -6508,12 +6506,10 @@ Proof.
               ertype. eapply ccmeta_conv.
               - ertype. eapply ccmeta_conv.
                 + ertype.
-                + cbn. lhs_ssimpl. reflexivity.
+                + cbn. rasimpl. unfold_funcomp. cbn. reflexivity.
               - cbn. reflexivity.
             }
-            * cbn. lhs_ssimpl. f_equal.
-              ssimpl. rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-              reflexivity.
+            * cbn. rasimpl. reflexivity.
           + reflexivity.
         - eapply ccmeta_conv.
           + ertype.
@@ -6531,15 +6527,15 @@ Proof.
                   * apply ccmeta_refl.
                     erewrite erase_ren.
                     2,3: eauto using rscoping_S, rscoping_comp_S.
-                    lhs_ssimpl. rewrite <- renRen_cterm.
+                    rasimpl. rewrite <- renRen_cterm.
                     rewrite <- epm_lift_eq. reflexivity.
                   * apply ccmeta_refl.
                     erewrite !erase_ren.
                     2-5: eauto using rscoping_S, rscoping_comp_S.
-                    lhs_ssimpl. rewrite <- !funcomp_assoc.
-                    rewrite <- rinstInst'_cterm. rewrite !funcomp_assoc.
-                    rewrite <- renRen_cterm.
-                    rewrite <- epm_lift_eq. reflexivity.
+                    rasimpl. rewrite <- renRen_cterm.
+                    rewrite <- epm_lift_eq.
+                    unfold_funcomp. cbn.
+                    reflexivity.
                 + ertype.
                   * {
                     eapply ccmeta_conv.
@@ -6559,8 +6555,7 @@ Proof.
                         * cbn. reflexivity.
                     - reflexivity.
                   }
-              - cbn. f_equal. ssimpl. rewrite <- !funcomp_assoc.
-                rewrite <- rinstInst'_cterm. reflexivity.
+              - cbn. f_equal. rasimpl. reflexivity.
             }
             cbn. eapply ccmeta_conv.
             * {
@@ -6570,17 +6565,16 @@ Proof.
                   * {
                     eapply ccmeta_conv.
                     - ertype.
-                    - cbn. lhs_ssimpl. reflexivity.
+                    - cbn. rasimpl. unfold_funcomp. cbn. reflexivity.
                   }
                   * eapply ccmeta_conv. 1: ertype.
                     reflexivity.
-                + cbn. lhs_ssimpl. rewrite <- !funcomp_assoc.
-                  rewrite <- rinstInst'_cterm. reflexivity.
+                + cbn. rasimpl. reflexivity.
               - eapply ccmeta_conv.
                 + ertype.
                 + reflexivity.
             }
-            * cbn. f_equal. ssimpl. reflexivity.
+            * cbn. f_equal. rasimpl. reflexivity.
           + cbn. reflexivity.
       }
       eapply param_revive_typing in h3 as hze. 2: ertype.
@@ -6602,17 +6596,15 @@ Proof.
         1:{
           apply cconv_sym. erewrite erase_ren.
           2-3: eauto using rscoping_S, rscoping_comp_S.
-          lhs_ssimpl. rewrite <- renRen_cterm. rewrite <- epm_lift_eq.
+          rasimpl. rewrite <- renRen_cterm. rewrite <- epm_lift_eq.
           econv.
         }
         apply cconv_sym. constructor. constructor.
-        2:{ lhs_ssimpl. econv. }
+        2:{ rasimpl. unfold funcomp. cbn. econv. }
         apply ccmeta_refl.
         erewrite !erase_ren.
           2-5: eauto using rscoping_S, rscoping_comp_S.
-          lhs_ssimpl. rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-          rewrite !funcomp_assoc.
-          rewrite <- renRen_cterm. rewrite <- epm_lift_eq.
+          rasimpl. rewrite <- renRen_cterm. rewrite <- epm_lift_eq.
           reflexivity.
       }
       2:{
@@ -6648,8 +6640,7 @@ Proof.
         constructor.
         - apply ccmeta_refl.
           erewrite !param_ren. 2-5: eauto using rscoping_S, rscoping_comp_S.
-          lhs_ssimpl. rewrite !pren_S_pw. lhs_ssimpl.
-          rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
+          rasimpl. rewrite !pren_S_pw. rasimpl.
           reflexivity.
         - apply ccmeta_refl. rewrite epm_lift_eq. cbn. reflexivity.
       }
@@ -6771,7 +6762,7 @@ Proof.
               - reflexivity.
             }
             * cbn. reflexivity.
-          + cbn. ssimpl. apply cconv_sym. econv.
+          + cbn. rasimpl. apply cconv_sym. econv.
           + eapply ccmeta_conv.
             * {
               ertype. eapply ccmeta_conv.
@@ -6806,7 +6797,7 @@ Proof.
       constructor.
       1:{
         erewrite erase_ren. 2,3: eauto using rscoping_S, rscoping_comp_S.
-        lhs_ssimpl. rewrite <- rinstInst'_cterm.
+        rasimpl.
         change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
         econv.
       }
@@ -6836,42 +6827,28 @@ Proof.
       1:{
         constructor. constructor.
         apply ccmeta_refl.
-        lhs_ssimpl.
+        rasimpl.
         rewrite <- !funcomp_assoc.
         change (S >> vreg) with (vreg >> S >> S).
-        rewrite !funcomp_assoc.
-        rewrite <- renSubst_cterm.
+        rasimpl. rewrite <- renRen_cterm.
         change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
-        etransitivity.
-        1:{
-          eapply ext_cterm_scoped with (θ := S >> S >> cvar).
-          1:{ eapply scoping_epm_lift. 2: reflexivity. eapply erase_scoping. }
-          intros [| []] hx. all: reflexivity.
-        }
-        rewrite <- rinstInst'_cterm. reflexivity.
+        reflexivity.
       }
       change (vreg ⋅ ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
       constructor.
       1:{
         constructor. 2: econv.
         constructor. all: apply ccmeta_refl.
-        - lhs_ssimpl.
+        - rasimpl.
           rewrite <- !funcomp_assoc.
           change (S >> vreg) with (vreg >> S >> S).
-          rewrite !funcomp_assoc.
-          rewrite <- renSubst_cterm.
+          rasimpl.
+          rewrite <- renRen_cterm.
           change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
-          etransitivity.
-          1:{
-            eapply ext_cterm_scoped with (θ := S >> S >> S >> cvar).
-            1:{ eapply scoping_epm_lift. 2: reflexivity. eapply erase_scoping. }
-            intros [| []] hx. all: reflexivity.
-          }
-          rewrite <- rinstInst'_cterm. reflexivity.
-        - lhs_ssimpl. rewrite pren_S_pw. lhs_ssimpl.
-          rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
           reflexivity.
-        - lhs_ssimpl. rewrite rpm_lift_eq. cbn. reflexivity.
+        - rasimpl. rewrite pren_S_pw. rasimpl.
+          reflexivity.
+        - rasimpl. rewrite rpm_lift_eq. cbn. unfold funcomp. reflexivity.
         - reflexivity.
       }
       instantiate (1 := if isKind m then _ else if isProp m then _ else _).
@@ -6942,13 +6919,13 @@ Proof.
         eapply cconv_trans. 1: constructor.
         lhs_hnf. constructor.
         1:{
-          lhs_ssimpl. rewrite <- rinstInst'_cterm.
+          rasimpl.
           change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
           econv.
         }
         lhs_hnf. constructor.
         1:{
-          apply ccmeta_refl. lhs_ssimpl. rewrite <- !rinstInst'_cterm.
+          apply ccmeta_refl. rasimpl.
           reflexivity.
         }
         lhs_hnf.
@@ -6982,12 +6959,10 @@ Proof.
           | |- ?G ⊢ᶜ _ ≡ _ => remember G as C eqn:eC
           end.
           erewrite !erase_ren. 2-5: eauto using rscoping_S, rscoping_comp_S.
-          lhs_ssimpl. rewrite <- !funcomp_assoc.
+          rasimpl. rewrite <- !funcomp_assoc.
           change ((S >> S) >> vreg) with (vreg >> S >> S >> S >> S).
-          rewrite !funcomp_assoc. rewrite <- renSubst_cterm.
+          rasimpl. rewrite <- renRen_cterm.
           change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
-          lhs_ssimpl.
-          rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
           econv.
         }
         lhs_hnf.
@@ -6997,23 +6972,16 @@ Proof.
           - lhs_hnf. constructor.
             + lhs_hnf. apply ccmeta_refl. cbn.
               erewrite !erase_ren. 2-5: eauto using rscoping_S, rscoping_comp_S.
-              hide_rhs rhs. asimpl. autosubst_unfold. asimpl.
-              repeat unfold_funcomp.
-              rewrite ?renRen_cterm. rewrite <- !funcomp_assoc.
+              rasimpl. rewrite <- !funcomp_assoc.
               change ((S >> S) >> vreg) with (vreg >> S >> S >> S >> S).
-              rewrite !funcomp_assoc. rewrite <- !renRen_cterm.
+              rasimpl. rewrite <- renRen_cterm.
               change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
-              resubst. asimpl. repeat unfold_funcomp.
-              ssimpl.
-              rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-              subst rhs. reflexivity.
+              reflexivity.
             + apply ccmeta_refl. cbn.
               change (vreg ⋅ ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
               erewrite !param_ren. 2-5: eauto using rscoping_S, rscoping_comp_S.
               rewrite !pren_S_pw.
-              lhs_ssimpl.
-              rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-              reflexivity.
+              rasimpl. reflexivity.
             + apply ccmeta_refl. cbn. change (rpm_lift ?t) with (vreg ⋅ t).
               cbn. reflexivity.
             + apply ccmeta_refl. cbn. reflexivity.
@@ -7032,16 +7000,11 @@ Proof.
           change (vreg ⋅ ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
           erewrite !erase_ren. 2-7: eauto using rscoping_S, rscoping_comp_S.
           cbn. eapply congr_cEl. eapply congr_capp. 2: reflexivity.
-          hide_rhs rhs. asimpl. autosubst_unfold.
-          repeat unfold_funcomp.
-          rewrite ?renRen_cterm. rewrite <- !funcomp_assoc.
+          rasimpl. rewrite <- !funcomp_assoc.
           change (((S >> S) >> S) >> vreg) with (vreg >> S >> S >> S >> S >> S >> S).
-          rewrite !funcomp_assoc. rewrite <- !renRen_cterm.
+          rasimpl. rewrite <- renRen_cterm.
           change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
-          resubst. asimpl. repeat unfold_funcomp.
-          ssimpl.
-          rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-          subst rhs. reflexivity.
+          rasimpl. reflexivity.
         }
         cbn. constructor.
         1:{
@@ -7056,8 +7019,7 @@ Proof.
           apply ccmeta_refl.
           change (vreg ⋅ ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
           erewrite !param_ren. 2-7: eauto using rscoping_S, rscoping_comp_S.
-          rewrite !pren_S_pw. lhs_ssimpl.
-          rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
+          rewrite !pren_S_pw. rasimpl.
           reflexivity.
         }
         unfold shift. change (var_zero) with 0.
@@ -7072,8 +7034,7 @@ Proof.
             erewrite !param_ren. 2-9: eauto using rscoping_S, rscoping_comp_S.
             rewrite !pren_S_pw.
             change (rpm_lift ?t) with (vreg ⋅ t). cbn.
-            lhs_ssimpl.
-            rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
+            rasimpl.
             reflexivity.
           - constructor. 2: econv.
             constructor.
@@ -7118,12 +7079,12 @@ Proof.
             * eapply ccmeta_conv. 1: ertype.
               reflexivity.
             * eapply ccmeta_conv. 1: ertype.
-              cbn. f_equal. f_equal. ssimpl. reflexivity.
+              cbn. f_equal. f_equal. rasimpl. reflexivity.
           + reflexivity.
         - eapply ccmeta_conv.
           + ertype. eapply ccmeta_conv.
             * ertype.
-            * cbn. f_equal. ssimpl. reflexivity.
+            * cbn. f_equal. rasimpl. reflexivity.
           + reflexivity.
         - eapply ccmeta_conv.
           + ertype. eapply ccmeta_conv.
@@ -7134,15 +7095,12 @@ Proof.
                   * ertype. eapply ccmeta_conv. 1: ertype.
                     cbn. reflexivity.
                   * cbn. reflexivity.
-                + cbn. f_equal. ssimpl.
-                  rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
+                + cbn. f_equal. rasimpl.
                   reflexivity.
-              - cbn. f_equal. f_equal. ssimpl.
-                rewrite <- !funcomp_assoc. rewrite <- !rinstInst'_cterm.
+              - cbn. f_equal. f_equal. rasimpl.
                 reflexivity.
             }
-            * cbn. f_equal. f_equal. f_equal. ssimpl.
-              rewrite <- !funcomp_assoc. rewrite <- !rinstInst'_cterm.
+            * cbn. f_equal. f_equal. f_equal. rasimpl.
               reflexivity.
           + reflexivity.
         - eapply ccmeta_conv.
@@ -7160,7 +7118,7 @@ Proof.
                     eapply cconv_trans. 1: constructor.
                     constructor.
                     1:{
-                      apply ccmeta_refl. ssimpl. reflexivity.
+                      apply ccmeta_refl. rasimpl. reflexivity.
                     }
                     eapply cconv_trans. 1: constructor.
                     eapply cconv_trans. 1: constructor.
@@ -7168,10 +7126,7 @@ Proof.
                     - apply ccmeta_refl.
                       erewrite !erase_ren.
                       2-5: eauto using rscoping_S, rscoping_comp_S.
-                      lhs_ssimpl. rewrite <- !funcomp_assoc.
-                      rewrite <- rinstInst'_cterm.
-                      rewrite !funcomp_assoc.
-                      rewrite <- renRen_cterm.
+                      rasimpl. rewrite <- renRen_cterm.
                       change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
                       reflexivity.
                     - eapply cconv_trans. 1: constructor.
@@ -7180,26 +7135,16 @@ Proof.
                       2-15: eauto using rscoping_S, rscoping_comp_S.
                       eapply congr_cPi. 1: reflexivity.
                       + eapply congr_cEl. eapply congr_capp. 2: reflexivity.
-                        hide_rhs rhs. asimpl. autosubst_unfold.
-                        repeat unfold_funcomp.
-                        rewrite ?renRen_cterm, ?renSubst_cterm.
-                        ssimpl. rewrite <- !funcomp_assoc.
-                        rewrite <- rinstInst'_cterm.
-                        rewrite !funcomp_assoc. rewrite <- renRen_cterm.
+                        rasimpl. rewrite <- renRen_cterm.
                         change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
-                        subst rhs. reflexivity.
+                        reflexivity.
                       + eapply congr_cEl. eapply congr_capp.
                         2:{
-                          lhs_ssimpl. reflexivity.
+                          rasimpl. unfold funcomp. cbn. reflexivity.
                         }
-                        hide_rhs rhs. asimpl. autosubst_unfold.
-                        repeat unfold_funcomp.
-                        rewrite ?renRen_cterm, ?renSubst_cterm.
-                        ssimpl. rewrite <- !funcomp_assoc.
-                        rewrite <- rinstInst'_cterm.
-                        rewrite !funcomp_assoc. rewrite <- renRen_cterm.
+                        rasimpl. rewrite <- renRen_cterm.
                         change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
-                        subst rhs. reflexivity.
+                        reflexivity.
                   }
                   * {
                     cbn. ertype.
@@ -7210,7 +7155,7 @@ Proof.
                     - eapply ccmeta_conv.
                       + ertype. eapply ccmeta_conv. 1: ertype.
                         cbn. f_equal. f_equal. f_equal.
-                        ssimpl. reflexivity.
+                        rasimpl. reflexivity.
                       + reflexivity.
                     - eapply ccmeta_conv.
                       + econstructor.
@@ -7225,17 +7170,16 @@ Proof.
                             * eapply ccmeta_conv. 1: ertype.
                               cbn. reflexivity.
                             * eapply ccmeta_conv. 1: ertype.
-                              cbn. f_equal. f_equal. ssimpl. reflexivity.
+                              cbn. f_equal. f_equal. rasimpl. reflexivity.
                             * eapply ccmeta_conv. 1: ertype.
                               reflexivity.
-                          - f_equal. f_equal. ssimpl. reflexivity.
+                          - f_equal. f_equal. rasimpl. reflexivity.
                         }
                       + reflexivity.
                   }
-                + cbn. f_equal. f_equal. f_equal. ssimpl.
-                  rewrite rinstInst'_cterm. reflexivity.
+                + cbn. f_equal. f_equal. f_equal. rasimpl. reflexivity.
               - cbn. f_equal. f_equal. f_equal.
-                ssimpl. rewrite rinstInst'_cterm. reflexivity.
+                rasimpl. reflexivity.
             }
             eapply ccmeta_conv.
             * {
@@ -7259,9 +7203,7 @@ Proof.
                       + ertype. eapply ccmeta_conv. 1: ertype.
                         reflexivity.
                     - cbn. eapply congr_cPi. 1: reflexivity.
-                      + lhs_ssimpl. rewrite <- !funcomp_assoc.
-                        rewrite <- rinstInst'_cterm.
-                        reflexivity.
+                      + rasimpl. reflexivity.
                       + reflexivity.
                   }
                   * {
@@ -7278,7 +7220,7 @@ Proof.
                 + econstructor.
                   1:{
                     eapply ccmeta_conv. 1: ertype.
-                    cbn. lhs_ssimpl. reflexivity.
+                    cbn. rasimpl. reflexivity.
                   }
                   1:{
                     eapply ccmeta_conv. 1: ertype.
@@ -7341,8 +7283,7 @@ Proof.
         2-19: eauto using rscoping_S, rscoping_comp_S.
         constructor.
         1:{
-          apply ccmeta_refl. lhs_ssimpl.
-          rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
+          apply ccmeta_refl. rasimpl.
           rewrite <- renRen_cterm.
           change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
           reflexivity.
@@ -7350,18 +7291,16 @@ Proof.
         eapply cconv_trans. 1: constructor.
         constructor.
         - constructor. constructor. 2: econv.
-          apply ccmeta_refl. lhs_ssimpl.
-          rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-          rewrite !funcomp_assoc. rewrite <- renRen_cterm.
+          apply ccmeta_refl. rasimpl.
+          rewrite <- renRen_cterm.
           change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
           reflexivity.
         - constructor. constructor.
-          + apply ccmeta_refl. lhs_ssimpl.
-            rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-            rewrite !funcomp_assoc. rewrite <- renRen_cterm.
+          + apply ccmeta_refl. rasimpl.
+            rewrite <- renRen_cterm.
             change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
             reflexivity.
-          + apply ccmeta_refl. lhs_ssimpl. cbn. reflexivity.
+          + apply ccmeta_refl. rasimpl. unfold funcomp. cbn. reflexivity.
       }
       2:{
         ertype.
@@ -7407,13 +7346,13 @@ Proof.
         eapply cconv_trans. 1: constructor.
         lhs_hnf. constructor.
         1:{
-          lhs_ssimpl. rewrite <- rinstInst'_cterm.
+          rasimpl.
           change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
           econv.
         }
         lhs_hnf. constructor.
         1:{
-          apply ccmeta_refl. lhs_ssimpl. rewrite <- !rinstInst'_cterm.
+          apply ccmeta_refl. rasimpl.
           reflexivity.
         }
         lhs_hnf.
@@ -7447,12 +7386,10 @@ Proof.
           | |- ?G ⊢ᶜ _ ≡ _ => remember G as C eqn:eC
           end.
           erewrite !erase_ren. 2-5: eauto using rscoping_S, rscoping_comp_S.
-          lhs_ssimpl. rewrite <- !funcomp_assoc.
+          rasimpl. rewrite <- !funcomp_assoc.
           change ((S >> S) >> vreg) with (vreg >> S >> S >> S >> S).
-          rewrite !funcomp_assoc. rewrite <- renSubst_cterm.
+          rasimpl. rewrite <- renRen_cterm.
           change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
-          lhs_ssimpl.
-          rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
           econv.
         }
         lhs_hnf.
@@ -7462,23 +7399,16 @@ Proof.
           - lhs_hnf. constructor.
             + lhs_hnf. apply ccmeta_refl. cbn.
               erewrite !erase_ren. 2-5: eauto using rscoping_S, rscoping_comp_S.
-              hide_rhs rhs. asimpl. autosubst_unfold. asimpl.
-              repeat unfold_funcomp.
-              rewrite ?renRen_cterm. rewrite <- !funcomp_assoc.
+              rasimpl. rewrite <- !funcomp_assoc.
               change ((S >> S) >> vreg) with (vreg >> S >> S >> S >> S).
-              rewrite !funcomp_assoc. rewrite <- !renRen_cterm.
+              rasimpl. rewrite <- renRen_cterm.
               change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
-              resubst. asimpl. repeat unfold_funcomp.
-              ssimpl.
-              rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-              subst rhs. reflexivity.
+              reflexivity.
             + apply ccmeta_refl. cbn.
               change (vreg ⋅ ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
               erewrite !param_ren. 2-5: eauto using rscoping_S, rscoping_comp_S.
               rewrite !pren_S_pw.
-              lhs_ssimpl.
-              rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-              reflexivity.
+              rasimpl. reflexivity.
             + apply ccmeta_refl. cbn. change (rpm_lift ?t) with (vreg ⋅ t).
               cbn. reflexivity.
             + apply ccmeta_refl. cbn. reflexivity.
@@ -7497,16 +7427,13 @@ Proof.
           change (vreg ⋅ ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
           erewrite !erase_ren. 2-7: eauto using rscoping_S, rscoping_comp_S.
           cbn. eapply congr_cEl. eapply congr_capp. 2: reflexivity.
-          hide_rhs rhs. asimpl. autosubst_unfold.
-          repeat unfold_funcomp.
-          rewrite ?renRen_cterm. rewrite <- !funcomp_assoc.
+          rasimpl.
+          rewrite <- !funcomp_assoc.
           change (((S >> S) >> S) >> vreg) with (vreg >> S >> S >> S >> S >> S >> S).
-          rewrite !funcomp_assoc. rewrite <- !renRen_cterm.
+          rewrite !funcomp_assoc. rasimpl.
+          rewrite <- renRen_cterm.
           change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
-          resubst. asimpl. repeat unfold_funcomp.
-          ssimpl.
-          rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-          subst rhs. reflexivity.
+          reflexivity.
         }
         cbn. constructor.
         1:{
@@ -7521,8 +7448,7 @@ Proof.
           apply ccmeta_refl.
           change (vreg ⋅ ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
           erewrite !param_ren. 2-7: eauto using rscoping_S, rscoping_comp_S.
-          rewrite !pren_S_pw. lhs_ssimpl.
-          rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
+          rewrite !pren_S_pw. rasimpl.
           reflexivity.
         }
         unfold shift. change (var_zero) with 0.
@@ -7537,9 +7463,7 @@ Proof.
             erewrite !param_ren. 2-9: eauto using rscoping_S, rscoping_comp_S.
             rewrite !pren_S_pw.
             change (rpm_lift ?t) with (vreg ⋅ t). cbn.
-            lhs_ssimpl.
-            rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-            reflexivity.
+            rasimpl. reflexivity.
           - constructor. 2: econv.
             constructor.
         }
@@ -7599,16 +7523,10 @@ Proof.
                   * ertype. eapply ccmeta_conv. 1: ertype.
                     cbn. reflexivity.
                   * cbn. reflexivity.
-                + cbn. f_equal. ssimpl.
-                  rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-                  reflexivity.
-              - cbn. f_equal. f_equal. ssimpl.
-                rewrite <- !funcomp_assoc. rewrite <- !rinstInst'_cterm.
-                reflexivity.
+                + cbn. f_equal. rasimpl. reflexivity.
+              - cbn. f_equal. f_equal. rasimpl. reflexivity.
             }
-            * cbn. f_equal. f_equal. f_equal. ssimpl.
-              rewrite <- !funcomp_assoc. rewrite <- !rinstInst'_cterm.
-              reflexivity.
+            * cbn. f_equal. f_equal. f_equal. rasimpl. reflexivity.
           + reflexivity.
         - eapply ccmeta_conv.
           + econstructor.
@@ -7632,23 +7550,21 @@ Proof.
                         * ertype. eapply ccmeta_conv. 1: ertype.
                           reflexivity.
                       + cbn. eapply congr_cPi. 1,3: reflexivity.
-                        lhs_ssimpl. rewrite <- !funcomp_assoc.
-                        rewrite <- rinstInst'_cterm. reflexivity.
+                        rasimpl. reflexivity.
                     - econstructor.
                       + eapply ccmeta_conv. 1: ertype.
                         cbn. reflexivity.
                       + eapply ccmeta_conv. 1: ertype.
-                        cbn. f_equal. ssimpl. reflexivity.
+                        cbn. f_equal. rasimpl. reflexivity.
                       + eapply ccmeta_conv. 1: ertype.
                         reflexivity.
                   }
                   * cbn. eapply congr_cPi. 1,3: reflexivity.
-                    lhs_ssimpl. rewrite <- !funcomp_assoc.
-                    rewrite <- !rinstInst'_cterm. reflexivity.
+                    rasimpl. reflexivity.
                 + econstructor.
                   1:{
                     eapply ccmeta_conv. 1: ertype.
-                    cbn. lhs_ssimpl. reflexivity.
+                    cbn. rasimpl. reflexivity.
                   }
                   1:{
                     eapply ccmeta_conv. 1: ertype.
@@ -7677,8 +7593,7 @@ Proof.
                   eapply ccmeta_conv. 1: ertype.
                   reflexivity.
               - cbn. eapply congr_cPi. 1,3: reflexivity.
-                lhs_ssimpl. rewrite <- !funcomp_assoc.
-                rewrite <- !rinstInst'_cterm. reflexivity.
+                rasimpl. reflexivity.
             }
             * {
               eapply ccmeta_conv.
@@ -7710,7 +7625,7 @@ Proof.
                                   constructor.
                                   1:{
                                     apply ccmeta_refl. cbn.
-                                    lhs_ssimpl.
+                                    rasimpl.
                                     rewrite <- renRen_cterm.
                                     change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
                                     reflexivity.
@@ -7743,10 +7658,7 @@ Proof.
                                     eapply congr_evec.
                                     erewrite !erase_ren.
                                     2-5: eauto using rscoping_S, rscoping_comp_S.
-                                    lhs_ssimpl.
-                                    rewrite <- !funcomp_assoc.
-                                    rewrite <- rinstInst'_cterm.
-                                    rewrite !funcomp_assoc.
+                                    rasimpl.
                                     rewrite <- renRen_cterm.
                                     change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
                                     reflexivity.
@@ -7766,10 +7678,7 @@ Proof.
                                     apply ccmeta_refl.
                                     erewrite !erase_ren.
                                     2-7: eauto using rscoping_S, rscoping_comp_S.
-                                    lhs_ssimpl.
-                                    rewrite <- !funcomp_assoc.
-                                    rewrite <- rinstInst'_cterm.
-                                    rewrite !funcomp_assoc.
+                                    rasimpl.
                                     rewrite <- renRen_cterm.
                                     change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
                                     reflexivity.
@@ -7792,14 +7701,15 @@ Proof.
                                       1: apply erase_scoping.
                                       intros x hx.
                                       cbn. unfold vreg.
-                                      ssimpl. reflexivity.
+                                      rasimpl. unfold funcomp. cbn.
+                                      reflexivity.
                                     }
                                     rewrite <- rinstInst'_cterm.
                                     rewrite !funcomp_assoc.
                                     rewrite <- renRen_cterm.
                                     change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
                                     reflexivity.
-                                  + lhs_ssimpl. reflexivity.
+                                  + rasimpl. unfold funcomp. cbn. reflexivity.
                                 - ertype.
                                   + eapply ccmeta_conv. 1: ertype.
                                     reflexivity.
@@ -7840,12 +7750,10 @@ Proof.
                           cbn. reflexivity.
                         }
                       + ertype. eapply ccmeta_conv. 1: ertype.
-                        cbn. f_equal. f_equal. ssimpl.
-                        rewrite rinstInst'_cterm. reflexivity.
+                        cbn. f_equal. f_equal. rasimpl.
+                        reflexivity.
                     - cbn. eapply congr_cPi. 1,3: reflexivity.
-                      lhs_ssimpl. rewrite <- !funcomp_assoc.
-                      rewrite <- rinstInst'_cterm.
-                      reflexivity.
+                      rasimpl. reflexivity.
                   }
                   * {
                     eapply ccmeta_conv. 1: ertype.
@@ -7889,9 +7797,7 @@ Proof.
         2-19: eauto using rscoping_S, rscoping_comp_S.
         constructor.
         1:{
-          apply ccmeta_refl. lhs_ssimpl.
-          rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-          rewrite !funcomp_assoc.
+          apply ccmeta_refl. rasimpl.
           rewrite <- renRen_cterm.
           change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
           reflexivity.
@@ -7899,18 +7805,16 @@ Proof.
         eapply cconv_trans. 1: constructor.
         constructor.
         - constructor. constructor. 2: econv.
-          apply ccmeta_refl. lhs_ssimpl.
-          rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-          rewrite !funcomp_assoc. rewrite <- renRen_cterm.
+          apply ccmeta_refl. rasimpl.
+          rewrite <- renRen_cterm.
           change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
           reflexivity.
         - constructor. constructor.
-          + apply ccmeta_refl. lhs_ssimpl.
-            rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-            rewrite !funcomp_assoc. rewrite <- renRen_cterm.
+          + apply ccmeta_refl. rasimpl.
+            rewrite <- renRen_cterm.
             change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
             reflexivity.
-          + apply ccmeta_refl. lhs_ssimpl. cbn. reflexivity.
+          + apply ccmeta_refl. rasimpl. unfold funcomp. cbn. reflexivity.
       }
       2:{
         ertype.
@@ -7945,30 +7849,30 @@ Proof.
         eapply congr_clam. 1-2: reflexivity.
         eapply congr_clam. 1: reflexivity.
         1:{
-          lhs_ssimpl. rewrite <- renRen_cterm.
+          rasimpl. rewrite <- renRen_cterm.
           change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
           reflexivity.
         }
         eapply congr_capp. 2: reflexivity.
         eapply congr_capp.
-        - lhs_ssimpl. rewrite <- renRen_cterm.
+        - rasimpl. rewrite <- renRen_cterm.
           change (ren_cterm vreg ⟦ ?G | ?t ⟧v) with (⟦ G | t ⟧pv).
           reflexivity.
         - eapply congr_evec_elim. 1,3: reflexivity.
           1:{
-            lhs_ssimpl. rewrite <- renRen_cterm.
+            rasimpl. rewrite <- renRen_cterm.
             change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
             reflexivity.
           }
           eapply congr_clam. 1: reflexivity.
           1:{
-            lhs_ssimpl. rewrite <- renRen_cterm.
+            rasimpl. rewrite <- renRen_cterm.
             change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
             reflexivity.
           }
           eapply congr_clam. 1: reflexivity.
           1:{
-            lhs_ssimpl. rewrite <- renRen_cterm.
+            rasimpl. rewrite <- renRen_cterm.
             change (ren_cterm vreg ⟦ ?G | ?t ⟧ε) with (⟦ G | t ⟧pε).
             reflexivity.
           }
@@ -8008,7 +7912,7 @@ Proof.
         constructor. 1: econv.
         constructor.
         1:{
-          apply ccmeta_refl. lhs_ssimpl.
+          apply ccmeta_refl. rasimpl.
           change (S >> vreg) with (vreg >> S >> S).
           rewrite <- !funcomp_assoc.
           change (S >> vreg) with (vreg >> S >> S).
@@ -8020,7 +7924,7 @@ Proof.
         rewrite !pren_S_pw.
         constructor.
         1:{
-          apply ccmeta_refl. lhs_ssimpl.
+          apply ccmeta_refl. rasimpl.
           rewrite <- !funcomp_assoc.
           change ((S >> S) >> vreg) with (vreg >> S >> S >> S >> S).
           rewrite !funcomp_assoc.
@@ -8030,7 +7934,7 @@ Proof.
         }
         constructor.
         1:{
-          apply ccmeta_refl. lhs_ssimpl.
+          apply ccmeta_refl. rasimpl.
           unfold vreg. cbn. reflexivity.
         }
         constructor. 2: econv.
@@ -8046,9 +7950,7 @@ Proof.
           cbn. econv.
         }
         constructor.
-        - apply ccmeta_refl. lhs_ssimpl.
-          rewrite <- !funcomp_assoc. rewrite <- rinstInst'_cterm.
-          reflexivity.
+        - apply ccmeta_refl. rasimpl. reflexivity.
         - eapply cconv_trans. 1: constructor.
           cbn. econv.
       }
@@ -8076,7 +7978,7 @@ Proof.
             * eapply ccmeta_conv. 1: ertype.
               reflexivity.
             * eapply ccmeta_conv. 1: ertype.
-              cbn. f_equal. f_equal. lhs_ssimpl. reflexivity.
+              cbn. f_equal. f_equal. rasimpl. reflexivity.
           + reflexivity.
         - eapply ccmeta_conv.
           + ertype. eapply ccmeta_conv.
@@ -8113,8 +8015,7 @@ Proof.
                       reflexivity.
                   }
                   * cbn. eapply congr_cPi. 1,3: reflexivity.
-                    lhs_ssimpl. rewrite <- !funcomp_assoc.
-                    rewrite <- rinstInst'_cterm. reflexivity.
+                    rasimpl. reflexivity.
                 + ertype.
                   * eapply ccmeta_conv. 1: ertype.
                     reflexivity.
@@ -8123,8 +8024,7 @@ Proof.
                   * eapply ccmeta_conv. 1: ertype.
                     reflexivity.
               - cbn. eapply congr_cPi. 1,3: reflexivity.
-                lhs_ssimpl. rewrite <- !funcomp_assoc.
-                rewrite <- !rinstInst'_cterm.
+                rasimpl.
                 reflexivity.
             }
             * {

--- a/theories/Param.v
+++ b/theories/Param.v
@@ -1585,18 +1585,7 @@ Proof.
       ssimpl. rewrite psubst_SS. rasimpl.
       erewrite rinstInst'_cterm. reflexivity.
     + cbn. unfold plam. f_equal. f_equal.
-      * fail.
-        aunfold. minimize.
-        rewrite_strat (topdown (hints asimpl)). 3,5: exact _.
-        2: exact _.
-        2: exact _.
-        Set Printing All.
-        aunfold. minimize.
-        rewrite_strat (topdown (hints asimpl)). 3,5: exact _.
-        2: exact _.
-        2: exact _.
-        reflexivity.
-      setoid_rewrite autosubst_simpl_cterm_subst. rasimpl. f_equal. rasimpl. reflexivity.
+      * rasimpl. reflexivity.
       * rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
         rewrite psubst_SS. rasimpl. reflexivity.
     + cbn. unfold plam. f_equal. f_equal.
@@ -1672,7 +1661,29 @@ Proof.
     2:{ econstructor. eapply erase_scoping. }
     destruct md eqn:e.
     + reflexivity.
-    + unfold pcastTG. cbn. rasimpl. reflexivity.
+    + unfold pcastTG. cbn. rasimpl.
+
+        aunfold. minimize.
+        rewrite_strat (topdown (hints asimpl)). 2-61: try (exact _).
+        (** TODO
+          How do we solve this issue? If the rhs gets instantiated before
+          it is solved we run into a problem. This comes from the fact that
+          setoid rewrite considers things a success even though it hasn't yet
+          found an instance.
+
+          Another way to solve this particular case is to remove RenSimpl but
+          that would break other things.
+          Although I expect most times there shouldn't be overlap between
+          evars, so why is this happening here?
+        **)
+
+
+
+      clear. f_equal. all: f_equal. all: f_equal. 1,3: f_equal.
+      1,3,4: f_equal. 4,5: f_equal. 4,5: f_equal. 6,7: f_equal.
+      7: f_equal. 7: f_equal.
+      all: rasimpl. all: reflexivity.
+      reflexivity.
     + unfold pcastTG. cbn. rasimpl. reflexivity.
     + unfold pcastP. cbn. rasimpl. reflexivity.
   - cbn. reflexivity.

--- a/theories/Param.v
+++ b/theories/Param.v
@@ -851,12 +851,12 @@ Proof.
     destruct (nth_error Δ n) eqn:e.
     + eapply hρ in e as e'. rewrite e'.
       destruct_if e1.
-      * unfold vreg, pren. rasimpl. f_equal.
+      * unfold vreg, pren. rasimpl. cbn [ren_cterm]. f_equal.
         replace (n * 2) with (2 * n) by lia.
         rewrite PeanoNat.Nat.div2_succ_double.
         rewrite PeanoNat.Nat.odd_succ.
         rewrite PeanoNat.Nat.even_mul. cbn. lia.
-      * unfold pren, vpar. rasimpl. f_equal.
+      * unfold pren, vpar. rasimpl. cbn [ren_cterm]. f_equal.
         replace (n * 2) with (2 * n) by lia.
         rewrite PeanoNat.Nat.div2_double.
         rewrite PeanoNat.Nat.odd_mul. cbn. lia.
@@ -1584,8 +1584,19 @@ Proof.
       eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
       ssimpl. rewrite psubst_SS. rasimpl.
       erewrite rinstInst'_cterm. reflexivity.
-    + cbn. f_equal. unfold plam. f_equal. f_equal.
-      * rasimpl. reflexivity.
+    + cbn. unfold plam. f_equal. f_equal.
+      * fail.
+        aunfold. minimize.
+        rewrite_strat (topdown (hints asimpl)). 3,5: exact _.
+        2: exact _.
+        2: exact _.
+        Set Printing All.
+        aunfold. minimize.
+        rewrite_strat (topdown (hints asimpl)). 3,5: exact _.
+        2: exact _.
+        2: exact _.
+        reflexivity.
+      setoid_rewrite autosubst_simpl_cterm_subst. rasimpl. f_equal. rasimpl. reflexivity.
       * rasimpl. eapply ext_cterm. intros [| []]. all: cbn. 1,2: reflexivity.
         rewrite psubst_SS. rasimpl. reflexivity.
     + cbn. unfold plam. f_equal. f_equal.

--- a/theories/Param.v
+++ b/theories/Param.v
@@ -5037,8 +5037,7 @@ Proof.
                   eapply ctyping_subst. 2: eassumption.
                   destruct (isKind mx) eqn:ek.
                   - constructor. 1: rasimpl. 1: constructor. 1: rasimpl.
-                    + rewrite <- !funcomp_assoc.
-                      apply crtyping_typing. ertype.
+                    + apply crtyping_typing. ertype.
                     + cbn. split.
                       * ertype.
                       * eapply ccmeta_conv. 1: ertype.
@@ -5049,8 +5048,7 @@ Proof.
                       * eapply ccmeta_conv. 1: ertype.
                         cbn. rasimpl. rewrite rinstInst'_cterm. reflexivity.
                   - constructor. 1: rasimpl. 1: constructor. 1: rasimpl.
-                    + rewrite <- !funcomp_assoc.
-                      apply crtyping_typing. ertype.
+                    + apply crtyping_typing. ertype.
                     + cbn. split.
                       * ertype.
                       * eapply ccmeta_conv. 1: ertype.
@@ -5077,8 +5075,7 @@ Proof.
                   - ertype. eapply ccmeta_conv.
                     + eapply ctyping_subst. 2: ertype.
                       cbn. constructor. 1: rasimpl. 1: constructor. 1: rasimpl.
-                      * rewrite <- !funcomp_assoc.
-                        apply crtyping_typing. ertype.
+                      * apply crtyping_typing. ertype.
                       * {
                         cbn. split.
                         - ertype.
@@ -5216,8 +5213,7 @@ Proof.
                   - eapply ctyping_subst. 2: ertype.
                     destruct (isKind mx) eqn:ekx.
                     + constructor. 1: rasimpl. 1: constructor. 1: rasimpl.
-                      * rewrite <- !funcomp_assoc.
-                        apply crtyping_typing. ertype.
+                      * apply crtyping_typing. ertype.
                       * {
                         cbn. split.
                         - ertype.
@@ -5232,8 +5228,7 @@ Proof.
                           cbn. rasimpl. rewrite rinstInst'_cterm. reflexivity.
                       }
                     + constructor. 1: rasimpl. 1: constructor. 1: rasimpl.
-                      * rewrite <- !funcomp_assoc.
-                        apply crtyping_typing. ertype.
+                      * apply crtyping_typing. ertype.
                       * {
                         cbn. split.
                         - ertype.

--- a/theories/Param.v
+++ b/theories/Param.v
@@ -1661,52 +1661,7 @@ Proof.
     2:{ econstructor. eapply erase_scoping. }
     destruct md eqn:e.
     + reflexivity.
-    + unfold pcastTG. cbn. rasimpl.
-
-        aunfold. minimize.
-
-        rewrite_strat (topdown (hints asimpl)).
-        (* Goal 54 is already instantiated!
-
-          So there is no way to solve it after the fact. But where is it coming
-          from??
-
-          I can test in the 1st goal to see where it appears by using f_equal
-          and the presence check.
-
-        *)
-        1:{
-          f_equal. f_equal. f_equal. f_equal. f_equal. f_equal. f_equal.
-          f_equal. f_equal. f_equal.
-          match goal with
-          | |- context [ PeanoNat.Nat.ones ] => idtac
-          end.
-        }
-
-        2-61: try (exact _).
-        Search PeanoNat.Nat.ones.
-        (** TODO
-          How do we solve this issue? If the rhs gets instantiated before
-          it is solved we run into a problem. This comes from the fact that
-          setoid rewrite considers things a success even though it hasn't yet
-          found an instance.
-
-          Another way to solve this particular case is to remove RenSimpl but
-          that would break other things.
-          Although I expect most times there shouldn't be overlap between
-          evars, so why is this happening here?
-
-          Maybe we should only rewrite ren and substs with triggers like for
-          terms? That might also save some time?
-        **)
-
-
-
-      clear. f_equal. all: f_equal. all: f_equal. 1,3: f_equal.
-      1,3,4: f_equal. 4,5: f_equal. 4,5: f_equal. 6,7: f_equal.
-      7: f_equal. 7: f_equal.
-      all: rasimpl. all: reflexivity.
-      reflexivity.
+    + unfold pcastTG. cbn. rasimpl. reflexivity.
     + unfold pcastTG. cbn. rasimpl. reflexivity.
     + unfold pcastP. cbn. rasimpl. reflexivity.
   - cbn. reflexivity.

--- a/theories/Revival.v
+++ b/theories/Revival.v
@@ -395,15 +395,15 @@ Proof.
       * cbn. unfold rev_subst. rasimpl. unfold ghv. cbn.
         destruct (nth_error Δ n) eqn:e1.
         -- destruct_if e2.
-          ++ ssimpl. erewrite revive_ren.
+          ++ unfold_funcomp. erewrite revive_ren.
             2:{ eapply rscoping_S. }
             2:{ eapply rscoping_comp_S. }
             rasimpl. reflexivity.
-          ++ ssimpl. erewrite erase_ren.
+          ++ unfold_funcomp. erewrite erase_ren.
             2:{ eapply rscoping_S. }
             2:{ eapply rscoping_comp_S. }
             rasimpl. reflexivity.
-        -- ssimpl. erewrite erase_ren.
+        -- unfold_funcomp. erewrite erase_ren.
           2:{ eapply rscoping_S. }
           2:{ eapply rscoping_comp_S. }
           rasimpl. reflexivity.
@@ -417,15 +417,15 @@ Proof.
         -- cbn. unfold rev_subst. unfold ghv. cbn.
           destruct (nth_error _ _) eqn:e1.
           ++ destruct_if e2.
-            ** ssimpl. erewrite revive_ren.
+            ** unfold_funcomp. erewrite revive_ren.
               2: eapply rscoping_S.
               2: eapply rscoping_comp_S.
               reflexivity.
-            ** ssimpl. erewrite erase_ren.
+            ** unfold_funcomp. erewrite erase_ren.
               2: eapply rscoping_S.
               2: eapply rscoping_comp_S.
               reflexivity.
-          ++ ssimpl. erewrite erase_ren.
+          ++ unfold_funcomp. erewrite erase_ren.
             2: eapply rscoping_S.
             2: eapply rscoping_comp_S.
             reflexivity.

--- a/theories/Revival.v
+++ b/theories/Revival.v
@@ -456,8 +456,7 @@ Proof.
     erewrite !erase_subst. 2-5: eassumption.
     rewrite !erase_rev_subst.
     destruct_if eg. 2: reflexivity.
-    cbn. f_equal. rasimpl. f_equal. f_equal.
-    rasimpl. reflexivity.
+    cbn. f_equal. rasimpl. reflexivity.
   - cbn.
     erewrite IHt3. 2,3: eassumption.
     erewrite IHt4. 2,3: eassumption.
@@ -1246,10 +1245,7 @@ Proof.
         + reflexivity.
     }
     etype. 1: reflexivity.
-    rasimpl in IHh4. rasimpl.
-    eapply ccmeta_conv. 1: eauto.
-    clear. f_equal. f_equal. f_equal. f_equal.
-    rasimpl. reflexivity.
+    rasimpl in IHh4. rasimpl. eauto.
   - cbn in hm. subst.
     cbn. remd. cbn.
     eapply erase_typing in h1 as hve. 2:{ remd. reflexivity. }
@@ -1365,9 +1361,9 @@ Proof.
             * {
               eapply ccmeta_conv.
               - rasimpl. ertype. 2: reflexivity.
-                rasimpl. tm_ssimpl. rasimpl.
+                rasimpl.
                 eapply ccmeta_conv. 1: ertype.
-                cbn. f_equal. f_equal. f_equal. rasimpl. reflexivity.
+                cbn. reflexivity.
               - reflexivity.
             }
             * {

--- a/theories/Revival.v
+++ b/theories/Revival.v
@@ -1347,7 +1347,7 @@ Proof.
         - econstructor.
           + ertype. 2: reflexivity.
             eapply ccmeta_conv. 1: ertype.
-            cbn. reflexivity.
+            cbn. rasimpl. reflexivity.
           + cbn. econv. apply cconv_sym. econv.
           + rasimpl. ertype.
             * {
@@ -1364,17 +1364,19 @@ Proof.
               reflexivity.
             * {
               eapply ccmeta_conv.
-              - ertype. 2: reflexivity.
+              - rasimpl. ertype. 2: reflexivity.
+                rasimpl. tm_ssimpl. rasimpl.
                 eapply ccmeta_conv. 1: ertype.
                 cbn. f_equal. f_equal. f_equal. rasimpl. reflexivity.
               - reflexivity.
             }
             * {
-              eapply ccmeta_conv.
+              rasimpl. eapply ccmeta_conv.
               - econstructor.
-                + eapply ccmeta_conv. 1: ertype.
+                + rasimpl. tm_ssimpl. rasimpl.
+                  eapply ccmeta_conv. 1: ertype.
                   cbn. reflexivity.
-                + ertype.
+                + rasimpl. ertype.
                   * {
                     eapply ccmeta_conv.
                     - ertype. reflexivity.

--- a/theories/Revival.v
+++ b/theories/Revival.v
@@ -456,7 +456,8 @@ Proof.
     erewrite !erase_subst. 2-5: eassumption.
     rewrite !erase_rev_subst.
     destruct_if eg. 2: reflexivity.
-    cbn. f_equal. rasimpl. reflexivity.
+    cbn. f_equal. rasimpl. f_equal. f_equal.
+    rasimpl. reflexivity.
   - cbn.
     erewrite IHt3. 2,3: eassumption.
     erewrite IHt4. 2,3: eassumption.
@@ -468,7 +469,10 @@ Proof.
     erewrite !erase_subst. 2-7: eassumption.
     rewrite !erase_rev_subst.
     destruct_if eg. 2: reflexivity.
-    cbn. unfold elength. rasimpl. reflexivity.
+    clear. cbn. unfold elength. f_equal. f_equal. f_equal.
+    all: f_equal. all: f_equal. 2-3: f_equal. 3-4: f_equal.
+    3-5: f_equal. 3,5: f_equal.
+    all: rasimpl. all: reflexivity.
   - cbn.
     destruct_ifs. 2: reflexivity.
     erewrite erase_subst. 2,3: eassumption.
@@ -1242,8 +1246,10 @@ Proof.
         + reflexivity.
     }
     etype. 1: reflexivity.
-    revert IHh4. rasimpl.
-    auto.
+    rasimpl in IHh4. rasimpl.
+    eapply ccmeta_conv. 1: eauto.
+    clear. f_equal. f_equal. f_equal. f_equal.
+    rasimpl. reflexivity.
   - cbn in hm. subst.
     cbn. remd. cbn.
     eapply erase_typing in h1 as hve. 2:{ remd. reflexivity. }
@@ -1277,6 +1283,7 @@ Proof.
       constructor. 1: econv.
       eapply cconv_trans. 1: constructor.
       erewrite !erase_ren. 2-19: eauto using rscoping_S, rscoping_comp_S.
+      rasimpl.
       constructor.
       1:{
         apply ccmeta_refl. rasimpl.
@@ -1286,10 +1293,13 @@ Proof.
       constructor.
       1:{
         apply ccmeta_refl. rasimpl.
+        apply (f_equal cEl). rasimpl.
+        apply (f_equal (λ x, capp x _)). rasimpl.
         reflexivity.
       }
       apply ccmeta_refl. rasimpl. cbn. rasimpl.
-      unfold shift.
+      apply (f_equal cEl). rasimpl.
+      apply (f_equal (λ x, capp x _)). rasimpl.
       reflexivity.
     }
     2:{
@@ -1301,7 +1311,7 @@ Proof.
       - eapply ccmeta_conv.
         + ertype. 2: reflexivity.
           eapply ccmeta_conv.
-          * ertype.
+          * rasimpl. ertype.
           * cbn. f_equal. rasimpl. reflexivity.
         + reflexivity.
       - eapply ccmeta_conv.
@@ -1328,6 +1338,7 @@ Proof.
       eapply ccmeta_conv. 1: ertype.
       reflexivity.
     }
+    rasimpl.
     eapply ccmeta_conv.
     + ertype. 2: reflexivity.
       eapply ccmeta_conv.
@@ -1349,7 +1360,7 @@ Proof.
                   * cbn. rasimpl. reflexivity.
               - reflexivity.
             }
-            * eapply ccmeta_conv. 1: ertype.
+            * rasimpl. tm_ssimpl. rasimpl. eapply ccmeta_conv. 1: ertype.
               reflexivity.
             * {
               eapply ccmeta_conv.

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -737,17 +737,17 @@ Hint Mode CTermQuote + - : typeclass_instances.
   exact (MkCTmQuote t q eq_refl)
   : typeclass_instances.
 
-Class ASimplification {A} (a s : A) := MkSimpl {
-  autosubst_simpl : a = s
+Class CTermSimplification (a s : cterm) := MkSimplCTm {
+  autosubst_simpl_cterm : a = s
 }.
 
-Arguments autosubst_simpl {A} a {s _}.
+Arguments autosubst_simpl_cterm a {s _}.
 
 (* Hint Mode ASimplification + + - : typeclass_instances. *)
 
-#[export] Instance ASimplification_cterm t {q} :
+#[export] Instance CTermSimplification_eval t {q} :
   CTermQuote t q →
-  ASimplification t (unquote_cterm (eval_cterm q)).
+  CTermSimplification t (unquote_cterm (eval_cterm q)).
 Proof.
   intros [->].
   constructor. apply eval_cterm_sound.
@@ -779,13 +779,13 @@ Qed.
 Ltac rasimpl :=
   repeat aunfold ;
   minimize ;
-  rewrite ?autosubst_simpl ;
+  rewrite ?autosubst_simpl_cterm ;
   minimize.
 
 Ltac setoid_rasimpl :=
   repeat aunfold ;
   minimize ;
-  setoid_rewrite ?autosubst_simpl ;
+  setoid_rewrite autosubst_simpl_cterm ;
   minimize.
 
 (* It's how it's done for asimpl but that's unsatisfactory *)

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -95,11 +95,11 @@ Inductive quoted_subst :=
 | qsubst_comp (s t : quoted_subst)
 | qsubst_compr (s : quoted_subst) (r : quoted_ren)
 | qsubst_rcomp (r : quoted_ren) (s : quoted_subst)
-| qsubst_cons (t : cterm) (s : quoted_subst)
+| qsubst_cons (t : quoted_cterm) (s : quoted_subst)
 | qsubst_id
-| qsubst_ren (r : quoted_ren).
+| qsubst_ren (r : quoted_ren)
 
-Inductive quoted_cterm :=
+with quoted_cterm :=
 | qatom (t : cterm)
 | qren (r : quoted_ren) (t : quoted_cterm)
 | qsubst (s : quoted_subst) (t : quoted_cterm).
@@ -126,12 +126,12 @@ Fixpoint unquote_subst q :=
   | qsubst_comp s t => funcomp (subst_cterm (unquote_subst s)) (unquote_subst t)
   | qsubst_compr s r => funcomp (unquote_subst s) (unquote_ren r)
   | qsubst_rcomp r s => funcomp (ren_cterm (unquote_ren r)) (unquote_subst s)
-  | qsubst_cons t s => scons t (unquote_subst s)
+  | qsubst_cons t s => scons (unquote_cterm t) (unquote_subst s)
   | qsubst_id => ids
   | qsubst_ren r => funcomp cvar (unquote_ren r)
-  end.
+  end
 
-Fixpoint unquote_cterm q :=
+with unquote_cterm q :=
   match q with
   | qatom t => t
   | qren r t => ren_cterm (unquote_ren r) (unquote_cterm t)
@@ -265,6 +265,32 @@ Definition test_qren_id r : qren_id_view r :=
   | r => not_qren_id r
   end.
 
+Inductive qsubst_ren_id_view : quoted_subst → Type :=
+| is_qsubst_ren r : qsubst_ren_id_view (qsubst_ren r)
+| is_qsubst_id : qsubst_ren_id_view qsubst_id
+| not_qsubst_ren_id s : qsubst_ren_id_view s.
+
+Definition test_qsubst_ren_id s : qsubst_ren_id_view s :=
+  match s with
+  | qsubst_ren r => is_qsubst_ren r
+  | qsubst_id => is_qsubst_id
+  | s => not_qsubst_ren_id s
+  end.
+
+(* TODO Could be improved like apply_ren *)
+Fixpoint apply_subst (s : quoted_subst) (n : quoted_nat) : quoted_cterm :=
+  match s, n with
+  | qsubst_atom s, _ => qatom (s (unquote_nat n))
+  | qsubst_id, _ => qatom (cvar (unquote_nat n))
+  | _, qnat_atom n => qatom (unquote_subst s n)
+  | qsubst_comp s1 s2, _ => qsubst s1 (apply_subst s2 n)
+  | qsubst_compr s r, _ => apply_subst s (apply_ren r n)
+  | qsubst_rcomp r s, _ => qren r (apply_subst s n)
+  | qsubst_cons t s, q0 => t
+  | qsubst_cons t s, qS n => apply_subst s n
+  | qsubst_ren r, n => qatom (cvar (unquote_nat (apply_ren r n)))
+  end.
+
 Fixpoint eval_subst (s : quoted_subst) : quoted_subst :=
   match s with
   | qsubst_comp u v =>
@@ -276,7 +302,7 @@ Fixpoint eval_subst (s : quoted_subst) : quoted_subst :=
     | es_comp_r u x y => qsubst_comp (qsubst_comp u x) y
     | es_compr_r u x y => qsubst_compr (qsubst_comp u x) y
     | es_rcomp_r u x y => qsubst_comp (qsubst_compr u x) y
-    | es_cons_r u t s => qsubst_cons (subst_cterm (unquote_subst u) t) (qsubst_comp u s)
+    | es_cons_r u t s => qsubst_cons (qsubst u t) (qsubst_comp u s)
     | es_ren_l r s => qsubst_rcomp r s
     | es_ren_r u r => qsubst_compr u r
     | es_other u v => qsubst_comp u v
@@ -288,8 +314,7 @@ Fixpoint eval_subst (s : quoted_subst) : quoted_subst :=
     | esr_id_l r => qsubst_ren r
     | esr_id_r s => s
     | esr_comp_r s x y => qsubst_compr (qsubst_compr s x) y
-    | esr_cons_r s n r =>
-      qsubst_cons (unquote_subst s (unquote_nat n)) (qsubst_compr s r)
+    | esr_cons_r s n r => qsubst_cons (apply_subst s n) (qsubst_compr s r)
     | esr_ren_l s r => qsubst_ren (qren_comp s r)
     | esr_cons_shift t s => s
     | esr_other s r => qsubst_compr s r
@@ -303,12 +328,12 @@ Fixpoint eval_subst (s : quoted_subst) : quoted_subst :=
     | ers_comp_r r x y => qsubst_comp (qsubst_rcomp r x) y
     | ers_compr_r r x y => qsubst_compr (qsubst_rcomp r x) y
     | ers_rcomp_r r x y => qsubst_rcomp (qren_comp r x) y
-    | ers_cons_r r t s =>
-      qsubst_cons (ren_cterm (unquote_ren r) t) (qsubst_rcomp r s)
+    | ers_cons_r r t s => qsubst_cons (qren r t) (qsubst_rcomp r s)
     | ers_ren_r r s => qsubst_ren (qren_comp r s)
     | ers_other r s => qsubst_rcomp r s
     end
   | qsubst_cons t s =>
+    let t := eval_cterm t in
     let s := eval_subst s in
     qsubst_cons t s
   | qsubst_ren r =>
@@ -318,21 +343,9 @@ Fixpoint eval_subst (s : quoted_subst) : quoted_subst :=
     | not_qren_id r => qsubst_ren r
     end
   | _ => s
-  end.
+  end
 
-Inductive qsubst_ren_id_view : quoted_subst → Type :=
-| is_qsubst_ren r : qsubst_ren_id_view (qsubst_ren r)
-| is_qsubst_id : qsubst_ren_id_view qsubst_id
-| not_qsubst_ren_id s : qsubst_ren_id_view s.
-
-Definition test_qsubst_ren_id s : qsubst_ren_id_view s :=
-  match s with
-  | qsubst_ren r => is_qsubst_ren r
-  | qsubst_id => is_qsubst_id
-  | s => not_qsubst_ren_id s
-  end.
-
-Fixpoint eval_cterm (t : quoted_cterm) : quoted_cterm :=
+with eval_cterm (t : quoted_cterm) : quoted_cterm :=
   match t with
   | qren r t =>
     let r := eval_ren r in
@@ -435,164 +448,183 @@ Proof.
       assumption.
 Qed.
 
-Ltac set_eval_subst na :=
-  lazymatch goal with
-  | |- context [ eval_subst ?s ] =>
-    set (na := eval_subst s) in * ;
-    clearbody na
-  end.
-
-Lemma eval_subst_sound :
-  ∀ s,
-    pointwise_relation _ eq (unquote_subst s) (unquote_subst (eval_subst s)).
+Lemma apply_subst_sound :
+  ∀ s n,
+    unquote_cterm (apply_subst s n) = unquote_subst s (unquote_nat n).
 Proof.
   intros s n.
   induction s in n |- *.
   all: try reflexivity.
-  - cbn. set_eval_subst es1. set_eval_subst es2.
-    destruct eval_subst_comp_c.
-    + cbn in *. unfold funcomp. rewrite IHs2.
-      etransitivity.
-      1:{
-        eapply subst_cterm_morphism. 1: eassumption.
-        reflexivity.
-      }
-      asimpl. reflexivity.
-    + cbn in *. unfold funcomp. rewrite IHs2.
-      etransitivity.
-      1:{
-        eapply subst_cterm_morphism. 1: eassumption.
-        reflexivity.
-      }
-      asimpl. reflexivity.
-    + cbn in *. unfold funcomp in *.
-      erewrite subst_cterm_morphism. 2,3: eauto.
-      asimpl. reflexivity.
-    + cbn in *. unfold funcomp in *.
-      erewrite subst_cterm_morphism. 2,3: eauto.
-      asimpl. reflexivity.
-    + cbn in *. unfold funcomp in *.
-      erewrite subst_cterm_morphism. 2,3: eauto.
-      asimpl. reflexivity.
-    + cbn in *. unfold funcomp.
-      erewrite subst_cterm_morphism. 2,3: eauto.
-      asimpl. destruct n. all: reflexivity.
-    + cbn in *. unfold funcomp in *.
-      rewrite IHs2.
-      rewrite rinstInst'_cterm. apply subst_cterm_morphism. 2: reflexivity.
-      intro. rewrite IHs1. unfold funcomp. reflexivity.
-    + cbn in *. unfold funcomp in *.
-      rewrite IHs2. cbn. rewrite IHs1. reflexivity.
-    + cbn in *. unfold funcomp. rewrite IHs2.
-      erewrite subst_cterm_morphism. 2,3: eauto.
-      reflexivity.
-  - cbn. set_eval_subst es.
-    remember (eval_ren _) as er eqn:e.
-    destruct eval_subst_compr_c.
-    + subst. cbn. unfold funcomp. rewrite IHs.
-      cbn. rewrite <- eval_ren_sound. reflexivity.
-    + unfold funcomp. rewrite eval_ren_sound, <- e. cbn.
-      rewrite IHs. reflexivity.
-    + unfold funcomp. rewrite eval_ren_sound, <- e. cbn.
-      rewrite IHs. reflexivity.
-    + unfold funcomp. rewrite eval_ren_sound, <- e. cbn.
-      rewrite IHs. destruct n. all: reflexivity.
-    + subst. cbn. unfold funcomp. rewrite <- eval_ren_sound.
-      rewrite IHs. reflexivity.
-    + unfold funcomp. rewrite eval_ren_sound, <- e. cbn.
-      rewrite IHs. cbn. reflexivity.
-    + subst. cbn. unfold funcomp. rewrite <- eval_ren_sound.
-      rewrite IHs. reflexivity.
-  - cbn. set_eval_subst es.
-    remember (eval_ren _) as er eqn:e.
-    destruct eval_subst_rcomp_c.
-    + unfold funcomp.
-      erewrite ren_cterm_morphism. 3: reflexivity.
-      2:{ intro. rewrite eval_ren_sound, <- e. reflexivity. }
-      cbn. asimpl. auto.
-    + subst. unfold funcomp. rewrite IHs. cbn. rewrite eval_ren_sound.
-      reflexivity.
-    + subst. unfold funcomp. rewrite IHs. cbn. unfold funcomp.
-      rewrite substRen_cterm. apply subst_cterm_morphism. 2: reflexivity.
-      intro. unfold funcomp. apply ren_cterm_morphism. 2: reflexivity.
-      intro. rewrite <- eval_ren_sound. reflexivity.
-    + subst. unfold funcomp. rewrite IHs. cbn. unfold funcomp.
-      apply ren_cterm_morphism. 2: reflexivity.
-      intro. rewrite <- eval_ren_sound. reflexivity.
-    + subst. unfold funcomp. rewrite IHs. cbn. unfold funcomp.
-      rewrite renRen_cterm. apply ren_cterm_morphism. 2: reflexivity.
-      intro. rewrite <- eval_ren_sound. reflexivity.
-    + subst. unfold funcomp. rewrite IHs. cbn.
-      destruct n.
-      * cbn. apply ren_cterm_morphism. 2: reflexivity.
-        intro. rewrite eval_ren_sound. reflexivity.
-      * cbn. unfold funcomp. apply ren_cterm_morphism. 2: reflexivity.
-        intro. rewrite eval_ren_sound. reflexivity.
-    + subst. unfold funcomp. rewrite IHs. cbn. unfold funcomp.
-      rewrite <- eval_ren_sound. reflexivity.
-    + subst. cbn. unfold funcomp. rewrite IHs.
-      apply ren_cterm_morphism. 2: reflexivity.
-      intro. rewrite eval_ren_sound. reflexivity.
-  - cbn. erewrite scons_morphism. 2,3: eauto.
-    reflexivity.
-  - cbn. remember (eval_ren _) as er eqn:e.
-    destruct test_qren_id.
-    + cbn. unfold funcomp. rewrite eval_ren_sound, <- e.
-      reflexivity.
-    + subst. cbn. unfold funcomp. rewrite <- eval_ren_sound.
-      reflexivity.
+  - cbn. destruct n.
+    + reflexivity.
+    + cbn. rewrite IHs2. reflexivity.
+    + cbn. rewrite IHs2. reflexivity.
+  - cbn. destruct n.
+    + reflexivity.
+    + rewrite IHs. rewrite apply_ren_sound. reflexivity.
+    + cbn. rewrite IHs. rewrite apply_ren_sound. reflexivity.
+  - cbn. destruct n.
+    + reflexivity.
+    + cbn. rewrite IHs. reflexivity.
+    + cbn. rewrite IHs. reflexivity.
+  - cbn. destruct n.
+    + reflexivity.
+    + reflexivity.
+    + cbn. rewrite IHs. reflexivity.
+  - cbn. destruct n.
+    + reflexivity.
+    + cbn. rewrite apply_ren_sound. reflexivity.
+    + cbn. rewrite apply_ren_sound. reflexivity.
 Qed.
 
-Lemma eval_cterm_sound :
-  ∀ t,
+Ltac set_eval_subst na :=
+  lazymatch goal with
+  | eval_subst_sound : ∀ s : quoted_subst, _ |- context [ eval_subst ?s ] =>
+    let IH := fresh "IH" in
+    pose proof (eval_subst_sound s) as IH ;
+    set (na := eval_subst s) in * ;
+    clearbody na
+  end.
+
+Fixpoint eval_subst_sound s :
+    pointwise_relation _ eq (unquote_subst s) (unquote_subst (eval_subst s))
+
+with eval_cterm_sound t :
     unquote_cterm t = unquote_cterm (eval_cterm t).
 Proof.
-  intros t.
-  induction t.
-  - reflexivity.
-  - cbn. remember (eval_cterm _) as et eqn:e in *.
-    destruct et.
-    + remember (eval_ren _) as rr eqn:er.
+  {
+    intros n.
+    destruct s.
+    all: try reflexivity.
+    - cbn. set_eval_subst es1. set_eval_subst es2.
+      destruct eval_subst_comp_c.
+      + cbn in *. unfold funcomp. rewrite IH, IH0.
+        asimpl. reflexivity.
+      + cbn in *. unfold funcomp. rewrite IH, IH0.
+        asimpl. reflexivity.
+      + cbn in *. unfold funcomp in *.
+        erewrite subst_cterm_morphism. 2,3: eauto.
+        asimpl. reflexivity.
+      + cbn in *. unfold funcomp in *.
+        erewrite subst_cterm_morphism. 2,3: eauto.
+        asimpl. reflexivity.
+      + cbn in *. unfold funcomp in *.
+        erewrite subst_cterm_morphism. 2,3: eauto.
+        asimpl. reflexivity.
+      + cbn in *. unfold funcomp.
+        erewrite subst_cterm_morphism. 2,3: eauto.
+        asimpl. destruct n. all: reflexivity.
+      + cbn in *. unfold funcomp in *.
+        rewrite IH, IH0.
+        rewrite rinstInst'_cterm. reflexivity.
+      + cbn in *. unfold funcomp in *.
+        rewrite IH, IH0. reflexivity.
+      + cbn in *. unfold funcomp. rewrite IH, IH0. reflexivity.
+    - cbn. set_eval_subst es.
+      remember (eval_ren _) as er eqn:e.
+      destruct eval_subst_compr_c.
+      + subst. cbn. unfold funcomp. rewrite IH.
+        cbn. rewrite <- eval_ren_sound. reflexivity.
+      + unfold funcomp. rewrite eval_ren_sound, <- e. cbn.
+        rewrite IH. reflexivity.
+      + unfold funcomp. rewrite eval_ren_sound, <- e. cbn.
+        rewrite IH. reflexivity.
+      + unfold funcomp. rewrite eval_ren_sound, <- e. cbn.
+        rewrite IH. destruct n. 2: reflexivity.
+        cbn. rewrite apply_subst_sound. reflexivity.
+      + subst. cbn. unfold funcomp. rewrite <- eval_ren_sound.
+        rewrite IH. reflexivity.
+      + unfold funcomp. rewrite eval_ren_sound, <- e. cbn.
+        rewrite IH. cbn. reflexivity.
+      + subst. cbn. unfold funcomp. rewrite <- eval_ren_sound.
+        rewrite IH. reflexivity.
+    - cbn. set_eval_subst es.
+      remember (eval_ren _) as er eqn:e.
+      destruct eval_subst_rcomp_c.
+      + unfold funcomp.
+        erewrite ren_cterm_morphism. 3: reflexivity.
+        2:{ intro. rewrite eval_ren_sound, <- e. reflexivity. }
+        cbn. asimpl. auto.
+      + subst. unfold funcomp. rewrite IH. cbn. rewrite eval_ren_sound.
+        reflexivity.
+      + subst. unfold funcomp. rewrite IH. cbn. unfold funcomp.
+        rewrite substRen_cterm. apply subst_cterm_morphism. 2: reflexivity.
+        intro. unfold funcomp. apply ren_cterm_morphism. 2: reflexivity.
+        intro. rewrite <- eval_ren_sound. reflexivity.
+      + subst. unfold funcomp. rewrite IH. cbn. unfold funcomp.
+        apply ren_cterm_morphism. 2: reflexivity.
+        intro. rewrite <- eval_ren_sound. reflexivity.
+      + subst. unfold funcomp. rewrite IH. cbn. unfold funcomp.
+        rewrite renRen_cterm. apply ren_cterm_morphism. 2: reflexivity.
+        intro. rewrite <- eval_ren_sound. reflexivity.
+      + subst. unfold funcomp. rewrite IH. cbn.
+        destruct n.
+        * cbn. apply ren_cterm_morphism. 2: reflexivity.
+          intro. rewrite eval_ren_sound. reflexivity.
+        * cbn. unfold funcomp. apply ren_cterm_morphism. 2: reflexivity.
+          intro. rewrite eval_ren_sound. reflexivity.
+      + subst. unfold funcomp. rewrite IH. cbn. unfold funcomp.
+        rewrite <- eval_ren_sound. reflexivity.
+      + subst. cbn. unfold funcomp. rewrite IH.
+        apply ren_cterm_morphism. 2: reflexivity.
+        intro. rewrite eval_ren_sound. reflexivity.
+    - cbn. erewrite scons_morphism. 2,3: eauto.
+      reflexivity.
+    - cbn. remember (eval_ren _) as er eqn:e.
       destruct test_qren_id.
-      * cbn. erewrite ren_cterm_morphism. 3: reflexivity.
-        2:{ intro. rewrite eval_ren_sound, <- er. reflexivity. }
-        cbn. asimpl. assumption.
-      * subst. cbn. rewrite IHt. cbn.
-        eapply ren_cterm_morphism. 2: reflexivity.
-        intro. apply eval_ren_sound.
-    + cbn. rewrite IHt. cbn. rewrite renRen_cterm.
-      apply ren_cterm_morphism. 2: reflexivity.
-      intro. unfold funcomp. rewrite <- eval_ren_sound. reflexivity.
-    + cbn. rewrite IHt. cbn.
-      rewrite substRen_cterm.
-      apply subst_cterm_morphism. 2: reflexivity.
-      intro. unfold funcomp.
-      rewrite rinstInst'_cterm.
-      apply subst_cterm_morphism. 2: reflexivity.
-      intro. unfold funcomp.
-      rewrite <- eval_ren_sound. reflexivity.
-  - cbn. remember (eval_cterm _) as et eqn:e in *.
-    destruct et.
-    + remember (eval_subst _) as ss eqn:es in *.
-      rewrite IHt. cbn.
-      destruct test_qsubst_ren_id.
-      * cbn. erewrite subst_cterm_morphism. 3: reflexivity.
-        2:{ intro. rewrite eval_subst_sound, <- es. reflexivity. }
-        cbn. rewrite rinstInst'_cterm. reflexivity.
-      * cbn. erewrite subst_cterm_morphism. 3: reflexivity.
-        2:{ intro. rewrite eval_subst_sound, <- es. reflexivity. }
-        cbn. asimpl. reflexivity.
-      * subst. cbn.
+      + cbn. unfold funcomp. rewrite eval_ren_sound, <- e.
+        reflexivity.
+      + subst. cbn. unfold funcomp. rewrite <- eval_ren_sound.
+        reflexivity.
+  }
+  {
+    destruct t.
+    - reflexivity.
+    - cbn. remember (eval_cterm _) as et eqn:e in *.
+      destruct et.
+      + remember (eval_ren _) as rr eqn:er.
+        destruct test_qren_id.
+        * rewrite eval_cterm_sound, <- e.
+          cbn. erewrite ren_cterm_morphism. 3: reflexivity.
+          2:{ intro. rewrite eval_ren_sound, <- er. reflexivity. }
+          cbn. asimpl. reflexivity.
+        * subst. cbn. rewrite eval_cterm_sound, <- e. cbn.
+          eapply ren_cterm_morphism. 2: reflexivity.
+          intro. apply eval_ren_sound.
+      + cbn. rewrite eval_cterm_sound, <- e. cbn. rewrite renRen_cterm.
+        apply ren_cterm_morphism. 2: reflexivity.
+        intro. unfold funcomp. rewrite <- eval_ren_sound. reflexivity.
+      + cbn. rewrite eval_cterm_sound, <- e. cbn.
+        rewrite substRen_cterm.
+        apply subst_cterm_morphism. 2: reflexivity.
+        intro. unfold funcomp.
+        rewrite rinstInst'_cterm.
+        apply subst_cterm_morphism. 2: reflexivity.
+        intro. unfold funcomp.
+        rewrite <- eval_ren_sound. reflexivity.
+    - cbn. remember (eval_cterm _) as et eqn:e in *.
+      destruct et.
+      + remember (eval_subst _) as ss eqn:es in *.
+        rewrite eval_cterm_sound, <- e. cbn.
+        destruct test_qsubst_ren_id.
+        * cbn. erewrite subst_cterm_morphism. 3: reflexivity.
+          2:{ intro. rewrite eval_subst_sound, <- es. reflexivity. }
+          cbn. rewrite rinstInst'_cterm. reflexivity.
+        * cbn. erewrite subst_cterm_morphism. 3: reflexivity.
+          2:{ intro. rewrite eval_subst_sound, <- es. reflexivity. }
+          cbn. asimpl. reflexivity.
+        * subst. cbn.
+          eapply subst_cterm_morphism. 2: reflexivity.
+          intro. apply eval_subst_sound.
+      + cbn. rewrite eval_cterm_sound, <- e. cbn. rewrite renSubst_cterm.
+        apply subst_cterm_morphism. 2: reflexivity.
+        intro. unfold funcomp. rewrite <- eval_subst_sound. reflexivity.
+      + cbn. rewrite eval_cterm_sound, <- e. cbn. rewrite substSubst_cterm.
         eapply subst_cterm_morphism. 2: reflexivity.
-        intro. apply eval_subst_sound.
-    + cbn. rewrite IHt. cbn. rewrite renSubst_cterm.
-      apply subst_cterm_morphism. 2: reflexivity.
-      intro. unfold funcomp. rewrite <- eval_subst_sound. reflexivity.
-    + cbn. rewrite IHt. cbn. rewrite substSubst_cterm.
-      eapply subst_cterm_morphism. 2: reflexivity.
-      intro. unfold funcomp.
-      eapply subst_cterm_morphism. 2: reflexivity.
-      intro. rewrite <- eval_subst_sound. reflexivity.
+        intro. unfold funcomp.
+        eapply subst_cterm_morphism. 2: reflexivity.
+        intro. rewrite <- eval_subst_sound. reflexivity.
+  }
 Qed.
 
 (** Quoting **)
@@ -657,14 +689,15 @@ Ltac quote_subst s :=
     let qr := quote_ren r in
     constr:(qsubst_compr qs qr)
   | scons ?t ?s =>
+    let qt := quote_cterm t in
     let q := quote_subst s in
-    constr:(qsubst_cons t q)
+    constr:(qsubst_cons qt q)
   | ids => constr:(qsubst_id)
   | cvar => constr:(qsubst_id)
   | _ => constr:(qsubst_atom s)
-  end.
+  end
 
-Ltac quote_cterm t :=
+with quote_cterm t :=
   lazymatch t with
   | ren_cterm ?r ?t =>
     let qr := quote_ren r in
@@ -721,7 +754,7 @@ Ltac post_process :=
     unquote_cterm eval_cterm test_qren_id test_qsubst_ren_id
     unquote_ren eval_ren apply_ren eval_ren_comp_c
     unquote_subst eval_subst eval_subst_compr_c eval_subst_comp_c
-    eval_subst_rcomp_c
+    eval_subst_rcomp_c apply_subst
     unquote_nat
     ren_cterm subst_cterm scons
   ] ;
@@ -732,7 +765,7 @@ Ltac post_process_in h :=
     unquote_cterm eval_cterm test_qren_id test_qsubst_ren_id
     unquote_ren eval_ren apply_ren eval_ren_comp_c
     unquote_subst eval_subst eval_subst_compr_c eval_subst_comp_c
-    eval_subst_rcomp_c
+    eval_subst_rcomp_c apply_subst
     unquote_nat
     ren_cterm subst_cterm scons
   ] in h ;
@@ -753,7 +786,7 @@ Hint Mode CTermSimplification + - : typeclass_instances.
       unquote_cterm eval_cterm test_qren_id test_qsubst_ren_id
       unquote_ren eval_ren apply_ren eval_ren_comp_c
       unquote_subst eval_subst eval_subst_compr_c eval_subst_comp_c
-      eval_subst_rcomp_c
+      eval_subst_rcomp_c apply_subst
       unquote_nat
       ren_cterm subst_cterm scons
     ]
@@ -780,7 +813,7 @@ Hint Mode RenSimplification + - : typeclass_instances.
       unquote_cterm eval_cterm test_qren_id test_qsubst_ren_id
       unquote_ren eval_ren apply_ren eval_ren_comp_c
       unquote_subst eval_subst eval_subst_compr_c eval_subst_comp_c
-      eval_subst_rcomp_c
+      eval_subst_rcomp_c apply_subst
       unquote_nat
       ren_cterm subst_cterm scons
     ]
@@ -807,7 +840,7 @@ Hint Mode CSubstSimplification + - : typeclass_instances.
       unquote_cterm eval_cterm test_qren_id test_qsubst_ren_id
       unquote_ren eval_ren apply_ren eval_ren_comp_c
       unquote_subst eval_subst eval_subst_compr_c eval_subst_comp_c
-      eval_subst_rcomp_c
+      eval_subst_rcomp_c apply_subst
       unquote_nat
       ren_cterm subst_cterm scons
     ]

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -765,7 +765,7 @@ Proof.
 Qed.
 
 Ltac rasimpl' :=
-  (rewrite_strat (topdown autosubst_simpl_cterm)) ;
+  (rewrite_strat (topdown (progress autosubst_simpl_cterm))) ;
   [ | (exact _) .. ] ;
   post_process.
 
@@ -785,7 +785,7 @@ Ltac minimize_in h :=
 Tactic Notation "minimize" "in" hyp(h) := minimize_in h.
 
 Ltac rasimpl'_in h :=
-  (rewrite_strat (topdown autosubst_simpl_cterm) in h) ;
+  (rewrite_strat (topdown (progress autosubst_simpl_cterm)) in h) ;
   [ | (exact _) .. ] ;
   post_process_in h.
 

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -772,7 +772,7 @@ Ltac rasimpl' :=
 Ltac rasimpl :=
   aunfold ;
   minimize ;
-  try rasimpl' ;
+  repeat rasimpl' ;
   minimize.
 
 (* Taken from core.minimize *)
@@ -792,7 +792,7 @@ Ltac rasimpl'_in h :=
 Ltac rasimpl_in h :=
   aunfold in h ;
   minimize in h ;
-  try rasimpl'_in h ;
+  repeat rasimpl'_in h ;
   minimize in h.
 
 Tactic Notation "rasimpl" "in" hyp(h) :=

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -117,7 +117,7 @@ Fixpoint unquote_ren q :=
   | qren_comp r q => funcomp (unquote_ren r) (unquote_ren q)
   | qren_cons n q => scons (unquote_nat n) (unquote_ren q)
   | qren_id => id
-  | qren_shift => shift
+  | qren_shift => S
   end.
 
 Fixpoint unquote_subst q :=
@@ -127,7 +127,7 @@ Fixpoint unquote_subst q :=
   | qsubst_compr s r => funcomp (unquote_subst s) (unquote_ren r)
   | qsubst_rcomp r s => funcomp (ren_cterm (unquote_ren r)) (unquote_subst s)
   | qsubst_cons t s => scons (unquote_cterm t) (unquote_subst s)
-  | qsubst_id => ids
+  | qsubst_id => cvar
   | qsubst_ren r => funcomp cvar (unquote_ren r)
   end
 

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -764,6 +764,13 @@ Proof.
   constructor. apply eval_cterm_sound.
 Qed.
 
+(* TODO
+
+  Below, progress is useless because autosubst_simpl_cterm will always progress
+  as long as we cannot test progress *after* the exact and post-process.
+
+*)
+
 Ltac rasimpl' :=
   (rewrite_strat (topdown (progress autosubst_simpl_cterm))) ;
   [ | (exact _) .. ] ;

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -72,6 +72,8 @@ Ltac ssimpl :=
     somehow. We also would need some preprocessing to move everything to using
     typeclasses notations.
     Preprocessing can be done on the fly though.
+  - IDEA: Using rewrite_strat I can invoke a hint database. This one could be
+    populated with autosubt_simpl_cterm and autosubt_simpl_term and so on.
 
 **)
 

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -854,7 +854,27 @@ Hint Mode CSubstSimplification + - : typeclass_instances.
 
 Create HintDb asimpl.
 
-#[export] Hint Rewrite -> autosubst_simpl_cterm : asimpl.
+Lemma autosubst_simpl_cterm_ren :
+  ∀ r t s,
+    CTermSimplification (ren_cterm r t) s →
+    ren_cterm r t = s.
+Proof.
+  intros r t s H.
+  apply autosubst_simpl_cterm, _.
+Qed.
+
+Lemma autosubst_simpl_cterm_subst :
+  ∀ r t s,
+    CTermSimplification (subst_cterm r t) s →
+    subst_cterm r t = s.
+Proof.
+  intros r t s H.
+  apply autosubst_simpl_cterm, _.
+Qed.
+
+(* #[export] Hint Rewrite -> autosubst_simpl_cterm : asimpl. *)
+#[export] Hint Rewrite -> autosubst_simpl_cterm_ren : asimpl.
+#[export] Hint Rewrite -> autosubst_simpl_cterm_subst : asimpl.
 #[export] Hint Rewrite -> autosubst_simpl_ren : asimpl.
 #[export] Hint Rewrite -> autosubst_simpl_csubst : asimpl.
 

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -732,20 +732,6 @@ Hint Mode CTermQuote + - : typeclass_instances.
 
 #[export] Hint Extern 10 (CTermQuote ?t _) =>
   let q := quote_cterm t in
-  (* let q :=
-    eval cbn [
-      unquote_cterm eval_cterm test_qren_id test_qsubst_ren_id
-      unquote_ren eval_ren apply_ren eval_ren_comp_c
-      unquote_subst eval_subst eval_subst_compr_c eval_subst_comp_c
-      eval_subst_rcomp_c
-      unquote_nat
-      ren_cterm subst_cterm scons
-    ] in
-    q
-  in
-  let q :=
-    eval unfold upRen_cterm_cterm, up_ren, up_cterm_cterm, var_zero in q
-  in *)
   exact (MkCTmQuote t q eq_refl)
   : typeclass_instances.
 
@@ -757,7 +743,7 @@ Arguments autosubst_simpl {A} a {s _}.
 
 (* Hint Mode ASimplification + + - : typeclass_instances. *)
 
-Lemma ASimplification_cterm t {q} :
+#[export] Instance ASimplification_cterm t {q} :
   CTermQuote t q →
   ASimplification t (unquote_cterm (eval_cterm q)).
 Proof.
@@ -765,7 +751,7 @@ Proof.
   constructor. apply eval_cterm_sound.
 Qed.
 
-Definition autosubst_simplify {A} {t s} (h : @ASimplification A t s) := s.
+(* Definition autosubst_simplify {A} {t s} (h : @ASimplification A t s) := s.
 
 #[export] Hint Extern 1 (ASimplification_cterm ?t _) =>
   let H := constr:(ASimplification_cterm t _) in
@@ -786,7 +772,7 @@ Definition autosubst_simplify {A} {t s} (h : @ASimplification A t s) := s.
     eval unfold upRen_cterm_cterm, up_ren, up_cterm_cterm, var_zero in s
   in
   exact (MkSimpl _ t s (@autosubst_simpl _ t s H))
-  : typeclass_instances.
+  : typeclass_instances. *)
 
 Ltac rasimpl :=
   repeat aunfold ;

--- a/theories/SubstNotations.v
+++ b/theories/SubstNotations.v
@@ -764,6 +764,10 @@ Proof.
   constructor. apply eval_cterm_sound.
 Qed.
 
+Create HintDb asimpl.
+
+#[export] Hint Rewrite -> autosubst_simpl_cterm : asimpl.
+
 (* TODO
 
   Below, progress is useless because autosubst_simpl_cterm will always progress
@@ -772,7 +776,7 @@ Qed.
 *)
 
 Ltac rasimpl' :=
-  (rewrite_strat (topdown (progress autosubst_simpl_cterm))) ;
+  (rewrite_strat (topdown (progress (hints asimpl)))) ;
   [ | (exact _) .. ] ;
   post_process.
 
@@ -792,7 +796,7 @@ Ltac minimize_in h :=
 Tactic Notation "minimize" "in" hyp(h) := minimize_in h.
 
 Ltac rasimpl'_in h :=
-  (rewrite_strat (topdown (progress autosubst_simpl_cterm)) in h) ;
+  (rewrite_strat (topdown (progress (hints asimpl))) in h) ;
   [ | (exact _) .. ] ;
   post_process_in h.
 


### PR DESCRIPTION
This new version should be more general and less ad-hoc than what I implemented in #13.
This time, I use the power of `rewrite_start` from `setoid_rewrite` to be able to use rewrite hints, providing a naturally extensible tactic.

Basically, the tactic triggers rewriting by lemmas conditioned by type classes whose resolution involves quoting and evaluating term expressions.

Currently running the whole build (https://github.com/TheoWinterhalter/ghost-reflection/actions/runs/10217142829) to compare with the 23 minutes the old version was taking and the 30 minutes of the `asimpl` version.
EDIT: It seems to also take 23 minutes.

However, this version can be used everywhere, while the previous `rasimpl` didn't work well under `forall`. It can also be used to rewrite under substitution and renaming judgments. The code base still doesn't reflect it fully as it takes some time to update the files to use `rasimpl` only.